### PR TITLE
Add unit test coverage for HomeNet bridge core

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "rs485-homenet-to-mqtt-bridge",
+  "private": true,
+  "version": "0.0.0",
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "core:dev": "npm run dev --workspace @rs485-homenet/core",
+    "service:dev": "npm run dev --workspace @rs485-homenet/service",
+    "ui:dev": "npm run dev --workspace @rs485-homenet/ui",
+    "core:build": "npm run build --workspace @rs485-homenet/core",
+    "service:build": "npm run build --workspace @rs485-homenet/service",
+    "ui:build": "npm run build --workspace @rs485-homenet/ui",
+    "lint": "npm run lint --workspaces",
+    "build": "npm run build --workspaces",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.7",
+    "vitest": "^1.5.0"
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@rs485-homenet/core",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -w -p tsconfig.json",
+    "lint": "tsc --noEmit -p tsconfig.json",
+    "test": "vitest run --runTestsByPath packages/core/test/homeNetBridge.test.ts"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "mqtt": "^5.3.4",
+    "serialport": "^12.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3"
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,31 @@
+import dotenv from 'dotenv';
+import { SerialPort } from 'serialport';
+import mqtt from 'mqtt';
+
+dotenv.config();
+
+export interface BridgeOptions {
+  serialPath: string;
+  baudRate: number;
+  mqttUrl: string;
+}
+
+export class HomeNetBridge {
+  private port: SerialPort;
+  private client: mqtt.MqttClient;
+
+  constructor(options: BridgeOptions) {
+    this.port = new SerialPort({ path: options.serialPath, baudRate: options.baudRate });
+    this.client = mqtt.connect(options.mqttUrl);
+  }
+
+  start() {
+    this.port.on('data', (data) => {
+      this.client.publish('homenet/raw', data.toString());
+    });
+  }
+}
+
+export function createBridge(options: BridgeOptions) {
+  return new HomeNetBridge(options);
+}

--- a/packages/core/test/homeNetBridge.test.ts
+++ b/packages/core/test/homeNetBridge.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+
+class FakeSerialPort extends EventEmitter {
+  public options: Record<string, unknown>;
+
+  constructor(options: Record<string, unknown>) {
+    super();
+    this.options = options;
+    serialPortInstances.push(this);
+  }
+}
+
+const serialPortInstances: FakeSerialPort[] = [];
+const publishMock = vi.fn();
+const mqttConnectMock = vi.fn(() => ({
+  publish: publishMock,
+}));
+
+vi.mock('serialport', () => ({
+  SerialPort: FakeSerialPort,
+}));
+
+vi.mock('mqtt', () => ({
+  default: {
+    connect: mqttConnectMock,
+  },
+}));
+
+vi.mock('dotenv', () => ({
+  default: {
+    config: vi.fn(),
+  },
+  config: vi.fn(),
+}));
+
+describe('HomeNetBridge', () => {
+  beforeEach(() => {
+    serialPortInstances.length = 0;
+    publishMock.mockClear();
+    mqttConnectMock.mockClear();
+    vi.resetModules();
+  });
+
+  it('publishes serial data to MQTT when started', async () => {
+    const { createBridge } = await import('../src/index.ts');
+
+    const bridge = createBridge({
+      serialPath: '/dev/ttyUSB0',
+      baudRate: 115200,
+      mqttUrl: 'mqtt://localhost',
+    });
+
+    bridge.start();
+
+    expect(mqttConnectMock).toHaveBeenCalledWith('mqtt://localhost');
+    expect(serialPortInstances).toHaveLength(1);
+
+    const port = serialPortInstances[0];
+    port.emit('data', Buffer.from('payload'));
+
+    expect(publishMock).toHaveBeenCalledWith('homenet/raw', 'payload');
+  });
+
+  it('passes serial configuration options to SerialPort', async () => {
+    const { createBridge } = await import('../src/index.ts');
+
+    const options = {
+      serialPath: '/dev/ttyS1',
+      baudRate: 57600,
+      mqttUrl: 'mqtt://example',
+    };
+
+    createBridge(options);
+
+    expect(serialPortInstances).toHaveLength(1);
+    expect(serialPortInstances[0].options).toMatchObject({
+      path: options.serialPath,
+      baudRate: options.baudRate,
+    });
+  });
+});

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@rs485-homenet/service",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "ts-node-dev --respawn --transpile-only src/server.ts",
+    "start": "node dist/server.js",
+    "lint": "tsc --noEmit -p tsconfig.json",
+    "test": "echo \"No tests yet\""
+  },
+  "dependencies": {
+    "@rs485-homenet/core": "workspace:*",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/packages/service/src/server.ts
+++ b/packages/service/src/server.ts
@@ -1,0 +1,48 @@
+import express from 'express';
+import path from 'node:path';
+import dotenv from 'dotenv';
+import { fileURLToPath } from 'node:url';
+import { createBridge } from '@rs485-homenet/core';
+
+dotenv.config();
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const app = express();
+const port = process.env.PORT ? Number(process.env.PORT) : 3000;
+
+app.use(express.json());
+
+app.get('/api/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.post('/api/bridge/start', (req, res) => {
+  const { serialPath, baudRate = 9600, mqttUrl } = req.body ?? {};
+  if (!serialPath || !mqttUrl) {
+    res.status(400).json({ error: 'serialPath and mqttUrl are required' });
+    return;
+  }
+
+  const bridge = createBridge({ serialPath, baudRate, mqttUrl });
+  bridge.start();
+
+  res.json({ status: 'started' });
+});
+
+const staticDir = path.resolve(__dirname, '../static');
+app.use(express.static(staticDir));
+
+app.get('*', (_req, res, next) => {
+  const indexPath = path.join(staticDir, 'index.html');
+  res.sendFile(indexPath, (err) => {
+    if (err) {
+      next();
+    }
+  });
+});
+
+app.listen(port, () => {
+  console.log(`Service listening on port ${port}`);
+});

--- a/packages/service/static/index.html
+++ b/packages/service/static/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>RS485 HomeNet Bridge Service</title>
+  </head>
+  <body>
+    <div id="app">Loading UI...</div>
+  </body>
+</html>

--- a/packages/service/tsconfig.json
+++ b/packages/service/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": false
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@rs485-homenet/ui",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "svelte-check --tsconfig ./tsconfig.json",
+    "test": "echo \"No tests yet\""
+  },
+  "dependencies": {
+    "svelte": "^4.2.12"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^2.5.3",
+    "@tsconfig/svelte": "^5.0.3",
+    "svelte-check": "^3.6.0",
+    "tslib": "^2.6.2",
+    "typescript": "^5.3.3",
+    "vite": "^5.1.0"
+  }
+}

--- a/packages/ui/public/index.html
+++ b/packages/ui/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>RS485 HomeNet Bridge UI</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/packages/ui/src/App.svelte
+++ b/packages/ui/src/App.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+  let serialPath = '';
+  let baudRate = 9600;
+  let mqttUrl = '';
+
+  async function startBridge() {
+    const response = await fetch('/api/bridge/start', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ serialPath, baudRate, mqttUrl })
+    });
+
+    if (!response.ok) {
+      const message = await response.text();
+      alert(`Failed to start bridge: ${message}`);
+      return;
+    }
+
+    alert('Bridge started successfully');
+  }
+</script>
+
+<main>
+  <h1>RS485 HomeNet Bridge</h1>
+  <form
+    on:submit|preventDefault={startBridge}
+    class="form"
+  >
+    <label>
+      Serial Path
+      <input bind:value={serialPath} placeholder="/dev/ttyUSB0" />
+    </label>
+
+    <label>
+      Baud Rate
+      <input type="number" bind:value={baudRate} min="0" step="1" />
+    </label>
+
+    <label>
+      MQTT URL
+      <input bind:value={mqttUrl} placeholder="mqtt://localhost" />
+    </label>
+
+    <button type="submit">Start Bridge</button>
+  </form>
+</main>
+
+<style>
+  :global(body) {
+    font-family: system-ui, sans-serif;
+    margin: 0;
+    background: #0f172a;
+    color: #e2e8f0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+  }
+
+  main {
+    background: rgba(15, 23, 42, 0.85);
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    padding: 2rem;
+    border-radius: 1rem;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.5);
+    width: min(90vw, 420px);
+  }
+
+  h1 {
+    margin-top: 0;
+    margin-bottom: 1.5rem;
+    font-size: 1.8rem;
+    text-align: center;
+  }
+
+  .form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    font-size: 0.95rem;
+  }
+
+  input {
+    padding: 0.75rem;
+    border-radius: 0.75rem;
+    border: 1px solid rgba(148, 163, 184, 0.5);
+    background: rgba(15, 23, 42, 0.7);
+    color: #e2e8f0;
+  }
+
+  button {
+    padding: 0.75rem;
+    border-radius: 9999px;
+    border: none;
+    background: linear-gradient(135deg, #2563eb, #7c3aed);
+    color: white;
+    cursor: pointer;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+  }
+
+  button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 24px rgba(59, 130, 246, 0.35);
+  }
+</style>

--- a/packages/ui/src/main.ts
+++ b/packages/ui/src/main.ts
@@ -1,0 +1,13 @@
+import App from './App.svelte';
+
+const target = document.getElementById('app');
+
+if (!target) {
+  throw new Error('Failed to find app element');
+}
+
+const app = new App({
+  target
+});
+
+export default app;

--- a/packages/ui/svelte.config.js
+++ b/packages/ui/svelte.config.js
@@ -1,0 +1,5 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+export default {
+  preprocess: [vitePreprocess()]
+};

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@tsconfig/svelte/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "$lib/*": ["src/lib/*"]
+    }
+  },
+  "include": [
+    "src/**/*",
+    "svelte.config.js",
+    "vite.config.ts"
+  ],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+export default defineConfig({
+  plugins: [svelte()],
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true
+  }
+});

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - packages/*

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmitOnError": false,
+    "baseUrl": "."
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['packages/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
- add a root test command with shared vitest tooling and pnpm workspace metadata
- wire package-level test scripts so workspaces participate cleanly in the new test workflow
- implement HomeNetBridge unit tests that mock serial and MQTT transports to verify publish behavior

## Testing
- `npm test --workspaces=false` *(fails: vitest binary unavailable because registry access is blocked in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fda0a9bd0832c98cae7e793ebab78)