### PR TITLE
Switch packet stream to WebSocket and bump addon version

### DIFF
--- a/hassio-addon/config.yaml
+++ b/hassio-addon/config.yaml
@@ -1,5 +1,5 @@
 name: Homenet2MQTT
-version: 0.0.6
+version: 0.0.7
 slug: h2m
 description: Bridge between RS485 HomeNet devices and MQTT.
 url: https://github.com/woooook/RS485-HomeNet-to-MQTT-bridge

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -17,7 +17,8 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "js-yaml": "^4.1.0",
-    "mqtt": "^5.3.4"
+    "mqtt": "^5.3.4",
+    "ws": "^8.18.3"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
       mqtt:
         specifier: ^5.3.4
         version: 5.14.1
+      ws:
+        specifier: ^8.18.3
+        version: 8.18.3
     devDependencies:
       '@types/express':
         specifier: ^4.17.21


### PR DESCRIPTION
## Summary
- replace the packet streaming SSE endpoint with a WebSocket server that broadcasts cached and live bridge events
- update the Svelte UI to consume WebSocket messages and manage connection lifecycle states
- add the ws dependency and bump the Home Assistant addon version to 0.0.7

## Testing
- Not run (Node.js/pnpm unavailable in the execution environment)

## Reproduction
1. pnpm install
2. pnpm --filter @rs485-homenet/service dev
3. pnpm --filter @rs485-homenet/ui dev


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69330b40d46c832ca1b38d19188309a6)