### PR TITLE
Add docs for serial and packet defaults

### DIFF
--- a/docs/config-schema/README.md
+++ b/docs/config-schema/README.md
@@ -1,0 +1,25 @@
+# 엔티티별 설정 스키마 가이드
+
+이 디렉터리는 RS485-HomeNet-to-MQTT-bridge에서 지원하는 엔티티 타입마다 YAML 설정을 작성하는 방법을 정리합니다. 각 문서는 `packages/core/config/*.homenet_bridge.yaml`의 실제 예제를 바탕으로 필수 필드, 상태 매핑, 명령 패턴을 설명합니다.
+
+## 문서 목록
+### 공통 상위 설정
+- [Serial](./serial.md)
+- [Packet Defaults](./packet-defaults.md)
+
+### 엔티티별
+- [Binary Sensor](./binary-sensor.md)
+- [Button](./button.md)
+- [Climate](./climate.md)
+- [Fan](./fan.md)
+- [Light](./light.md)
+- [Lock](./lock.md)
+- [Sensor](./sensor.md)
+- [Switch](./switch.md)
+- [Text Sensor](./text-sensor.md)
+- [Valve](./valve.md)
+
+### 활용 팁
+1. 기본 시리얼, 헤더/푸터, 체크섬 등 공통 설정은 상위 `homenet_bridge.packet_defaults`에서 정의하고, 엔티티 블록은 필요한 필드만 오버라이드합니다.
+2. `state`는 수신 패킷 매칭, `command_*`는 송신 패킷을 정의합니다. 람다(`!lambda`)를 사용하면 다른 엔티티 상태를 참조하거나 체크섬을 동적으로 계산할 수 있습니다.
+3. 예제를 그대로 복사하기보다 현장 장비 패킷 구조(오프셋, 길이, 비트마스크)를 확인한 뒤 값을 맞춰 넣으세요.

--- a/docs/config-schema/binary-sensor.md
+++ b/docs/config-schema/binary-sensor.md
@@ -1,0 +1,65 @@
+# Binary Sensor 스키마 작성법
+
+문 열림/도어벨/모션 감지처럼 2가지 상태를 가지는 센서는 `binary_sensor` 블록으로 정의합니다.
+
+## 필수 필드
+- `id`: MQTT 엔티티 ID.
+- `name`: 표시 이름.
+- `state`: 수신 패킷 매칭 조건. `data`와 `mask`를 통해 패킷 서명과 오프셋을 정의합니다.
+- `state_on`, `state_off`: 센서가 켜짐/꺼짐 상태로 판단되는 바이트 패턴.
+
+## 옵션 필드
+- `device_class`: Home Assistant용 센서 타입(예: `door`, `occupancy`).
+- `state_delay`: 장치가 연속으로 동일 패킷을 보낼 때 중복 처리를 줄이기 위한 지연.
+
+## 기본 예제 (현관 초인종)
+`packages/core/config/hyundai_door.homenet_bridge.yaml`에서는 도어벨을 아래처럼 정의합니다. `state`로 벨 채널을 매칭하고, `state_on`에서 초인종 이벤트를 감지합니다.
+
+```yaml
+binary_sensor:
+  - id: bell_room0
+    name: "초인종"
+    device_class: occupancy
+    state:
+      data: [0x7f, 0x00, 0x00, 0x00, 0x00]
+      mask: [0xff, 0xff, 0x00, 0x00, 0x00]
+    state_on:
+      offset: 1
+      data: [0x01]
+    state_off:
+      offset: 1
+      data: [0x00]
+```
+
+## 멀티채널 예제 (도어벨 + 공동 현관)
+여러 채널을 구분할 때는 `state`의 `data`/`mask`로 채널 비트를 분리하고, 각 센서마다 다른 `offset`이나 `data`를 줍니다. 아래는 `packages/core/config/kocom_door.homenet_bridge.yaml`에서 벨과 공동 현관을 별도 센서로 등록한 형태입니다.
+
+```yaml
+binary_sensor:
+  - id: doorbell
+    name: "세대 초인종"
+    state:
+      data: [0xaa, 0x55, 0x01, 0x00]
+    state_on:
+      offset: 2
+      data: [0x01]
+    state_off:
+      offset: 2
+      data: [0x00]
+
+  - id: lobby_bell
+    name: "공동 현관 벨"
+    state:
+      data: [0xaa, 0x55, 0x02, 0x00]
+    state_on:
+      offset: 2
+      data: [0x01]
+    state_off:
+      offset: 2
+      data: [0x00]
+```
+
+## 작성 체크리스트
+1. `state` 패턴이 너무 광범위하면 다른 패킷을 모두 잡아내므로 `mask`를 적극적으로 활용합니다.
+2. 장치에서 이벤트가 짧게 발생하는 경우 `state_delay`를 사용해 중복 트리거를 줄이고, MQTT 전송 폭주를 방지합니다.
+3. 동일한 오프셋을 여러 센서가 공유할 때는 `data`를 달리해 충돌을 막습니다.

--- a/docs/config-schema/button.md
+++ b/docs/config-schema/button.md
@@ -1,0 +1,43 @@
+# Button 스키마 작성법
+
+버튼은 MQTT를 통해 단발성 명령을 전송할 때 사용합니다. 패킷을 그대로 보내거나 람다로 가공할 수 있습니다.
+
+## 필수 필드
+- `id`, `name`: 엔티티 식별자와 표시 이름.
+- `command_press`: 버튼을 눌렀을 때 송신할 패킷 정의. 고정 배열 또는 `!lambda`로 작성합니다.
+
+## 옵션 필드
+- `icon`: UI용 아이콘 이름.
+- `device_class`: Home Assistant 버튼 클래스(`restart`, `identify` 등).
+- `packet_defaults` 오버라이드: 특정 버튼만 다른 헤더/푸터/체크섬을 사용할 때 중첩 설정을 덮어쓸 수 있습니다.
+
+## 기본 예제 (가스 밸브 닫기)
+`samsung_sds.homenet_bridge.yaml`은 가스 밸브 차단 버튼을 아래처럼 정의합니다. `command_press`에 즉시 전송할 바이트 시퀀스를 적습니다.
+
+```yaml
+button:
+  - id: gas_valve_close
+    name: "가스 차단"
+    icon: mdi:valve
+    command_press:
+      data: [0x20, 0x01, 0x00, 0x01, 0x00]
+```
+
+## 람다 예제 (체크섬 포함 명령)
+체크섬이 필요하거나 이전 상태를 참고해야 한다면 `!lambda`를 사용합니다. `kocom.homenet_bridge.yaml`에서는 조명 상태 갱신을 위해 두 개의 패킷을 연속 전송합니다.
+
+```yaml
+button:
+  - id: update_all
+    name: "상태 새로고침"
+    command_press: !lambda |-
+      return [
+        [0x30, 0xbc, 0x00, 0x0e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0, 0, 0, 0, 0, 0],
+        [0x30, 0xdc]
+      ];
+```
+
+## 작성 체크리스트
+1. 버튼은 상태를 가지지 않으므로 별도의 `state` 블록이 없습니다.
+2. 여러 패킷을 연속 전송해야 할 때는 배열 안에 배열로 나열합니다.
+3. 람다 내부에서 `getEntityState`를 활용하면 다른 엔티티의 현재 상태를 읽어 복합 명령을 만들 수 있습니다.

--- a/docs/config-schema/climate.md
+++ b/docs/config-schema/climate.md
@@ -1,0 +1,83 @@
+# Climate 스키마 작성법
+
+난방/냉난방 제어는 `climate` 엔티티로 정의하며, 현재 온도·목표 온도·모드 상태를 모두 매핑해야 합니다.
+
+## 필수 필드
+- `id`, `name`
+- `state`: 장비가 주기적으로 보내는 상태 패킷 서명.
+- `state_temperature_current`: 현재 온도 위치. `offset`, `length`, `precision`(소수점 자리) 설정.
+- `state_temperature_target`: 목표 온도 위치.
+- `state_action`: 동작 상태(`HEATING`, `OFF` 등) 판단용 필드.
+- `command_temperature`: 목표 온도를 설정하는 송신 패킷.
+
+## 옵션 필드
+- `visual`: UI에 노출할 온도 범위, 스텝(`min_temperature`, `max_temperature`, `temperature_step`).
+- `command_mode`: 난방/냉방/꺼짐 모드를 전환할 때 사용.
+- `command_update`: 상태 갱신을 강제로 요청하는 패킷.
+
+## 기본 예제 (목표/현재 온도 + 모드)
+`commax.homenet_bridge.yaml`은 목표 온도와 현재 온도를 각각 1바이트로 읽고, 모드를 `state_action`으로 매핑합니다.
+
+```yaml
+climate:
+  - id: heater_living
+    name: "거실 난방"
+    visual:
+      min_temperature: 5 °C
+      max_temperature: 35 °C
+      temperature_step: 1 °C
+    state:
+      data: [0xf7, 0x02, 0x0f, 0xff, 0x00]
+    state_temperature_current:
+      offset: 10
+      length: 1
+      precision: 0
+    state_temperature_target:
+      offset: 11
+      length: 1
+      precision: 0
+    state_action:
+      offset: 8
+      data: [0x80]
+      mask: [0x80]
+    command_temperature:
+      data: [0xaa, 0x0f, 0x01, 0x00]
+      value_offset: 3
+```
+
+## 확장 예제 (난방 밸브 + 업데이트 요청)
+`kocom_thinks.homenet_bridge.yaml`에서는 밸브 구역 코드와 온도를 함께 전송하며, `command_update`로 상태 새로고침 패킷을 별도로 지정합니다.
+
+```yaml
+climate:
+  - id: room_0_heater
+    name: "방0 난방"
+    visual:
+      min_temperature: 5 °C
+      max_temperature: 30 °C
+      temperature_step: 1 °C
+    state:
+      data: [0x30, 0xd0, 0x00, 0x36, 0x00]
+    state_temperature_current:
+      offset: 12
+      length: 1
+      precision: 0
+    state_temperature_target:
+      offset: 10
+      length: 1
+      precision: 0
+    state_action:
+      offset: 8
+      data: [0x80]
+      mask: [0x80]
+    command_temperature:
+      data: [0x30, 0xb8, 0x00, 0x36, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00]
+      value_offset: 9
+    command_update:
+      data: [0x30, 0xdc]
+```
+
+## 작성 체크리스트
+1. `state_action`은 장치마다 비트 위치가 다르므로 `mask`를 사용해 정확히 분리합니다.
+2. 목표 온도 바이트가 명령 패킷 어디에 들어가는지 `value_offset`/`length`를 맞춰야 합니다.
+3. 동일한 구역 코드가 필요하면 `data` 내 지역 인덱스 값(예: `0x00`, `0x01`)을 상단 주석으로 정리해 혼동을 줄입니다.

--- a/docs/config-schema/fan.md
+++ b/docs/config-schema/fan.md
@@ -1,0 +1,91 @@
+# Fan 스키마 작성법
+
+환풍기나 공기청정기처럼 속도를 가진 장치는 `fan` 엔티티로 정의합니다.
+
+## 필수 필드
+- `id`, `name`
+- `state`: 수신 패킷 서명.
+- `state_on`/`state_off`: 전원 상태 판별.
+- `state_speed`: 현재 속도 값을 읽는 위치. `offset`, `length`, `mapping`을 활용합니다.
+- `command_on`, `command_off`: 전원 제어 패킷.
+- `command_speed`: 속도 변경 패킷. `value_offset`로 속도 바이트 위치를 지정합니다.
+
+## 옵션 필드
+- `state_preset_mode`: 장치가 자체 프리셋(예: "수면")을 제공할 때 사용.
+- `supported_features`: `SET_SPEED`, `SET_PRESET_MODE` 등 지원 기능을 명시.
+
+## 기본 예제 (3단 속도)
+`cvnet.homenet_bridge.yaml`에서는 3단계 속도(저/중/고)를 `mapping`으로 대응시킵니다.
+
+```yaml
+fan:
+  - id: bathroom_fan
+    name: "욕실 환풍기"
+    supported_features: [SET_SPEED]
+    state:
+      data: [0xf7, 0x02, 0x2d, 0x00, 0x00]
+    state_on:
+      offset: 8
+      data: [0x01]
+    state_off:
+      offset: 8
+      data: [0x00]
+    state_speed:
+      offset: 9
+      length: 1
+      mapping:
+        0x01: low
+        0x02: medium
+        0x03: high
+    command_on:
+      data: [0xaa, 0x2d, 0x01]
+    command_off:
+      data: [0xaa, 0x2d, 0x00]
+    command_speed:
+      data: [0xaa, 0x2d, 0x00]
+      value_offset: 2
+```
+
+## 확장 예제 (바이패스 모드 + 업데이트)
+`samsung_sds.homenet_bridge.yaml`에서는 속도 외에 바이패스 모드(`preset_mode`)를 함께 제공하며, 상태 재요청 버튼을 별도로 둡니다.
+
+```yaml
+fan:
+  - id: ventilation
+    name: "환기"
+    supported_features: [SET_SPEED, SET_PRESET_MODE]
+    state:
+      data: [0x20, 0x0b, 0x00, 0x00, 0x00]
+    state_on:
+      offset: 2
+      data: [0x01]
+    state_off:
+      offset: 2
+      data: [0x00]
+    state_speed:
+      offset: 3
+      mapping:
+        0x01: low
+        0x02: medium
+        0x03: high
+    state_preset_mode:
+      offset: 4
+      mapping:
+        0x00: normal
+        0x01: bypass
+    command_on:
+      data: [0x20, 0x0b, 0x01]
+    command_off:
+      data: [0x20, 0x0b, 0x00]
+    command_speed:
+      data: [0x20, 0x0b, 0x00]
+      value_offset: 2
+    command_preset_mode:
+      data: [0x20, 0x0c, 0x00]
+      value_offset: 2
+```
+
+## 작성 체크리스트
+1. 속도값이 단순 증감인지, 고정 매핑인지 확인해 `mapping` 또는 `value_offset`만으로 처리할지 결정합니다.
+2. 전원 상태와 속도 오프셋이 동일할 수 있으므로 패킷을 캡쳐해 비트를 정확히 구분합니다.
+3. 상태 패킷과 명령 패킷의 헤더/푸터가 다르면 해당 엔티티 블록 안에서 `packet_defaults`를 재정의합니다.

--- a/docs/config-schema/light.md
+++ b/docs/config-schema/light.md
@@ -1,0 +1,65 @@
+# Light 스키마 작성법
+
+조명 스위치는 `light` 엔티티로 정의하며, 켜짐/꺼짐 상태와 명령 패킷을 지정합니다. 다채널 조명은 한 패킷에서 여러 비트를 읽거나, 람다 명령으로 다른 채널 상태를 참조할 수 있습니다.
+
+## 필수 필드
+- `id`, `name`
+- `state`: 상태 패킷 서명. `data`와 `mask`로 채널 구분.
+- `state_on`, `state_off`: 전원 상태 판단용 오프셋/데이터.
+- `command_on`, `command_off`: 전송 패킷. 고정 배열 또는 `!lambda`.
+
+## 옵션 필드
+- `command_update`: 상태 재요청 패킷.
+- `packet_defaults`: 특정 조명만 다른 헤더/체크섬을 사용할 때 덮어쓰기.
+
+## 기본 예제 (단일 채널)
+`cvnet.homenet_bridge.yaml`은 각 조명을 별도 패킷으로 제어합니다. `state_on/off`는 동일 오프셋에서 비트만 바뀝니다.
+
+```yaml
+light:
+  - id: living_light_1
+    name: "거실 메인등"
+    state:
+      data: [0xf7, 0x02, 0x25, 0x00, 0x00]
+    state_on:
+      offset: 8
+      data: [0x10]
+    state_off:
+      offset: 8
+      data: [0x00]
+    command_on:
+      data: [0xaa, 0x25, 0x10]
+    command_off:
+      data: [0xaa, 0x25, 0x00]
+```
+
+## 고급 예제 (상호 참조 람다)
+`kocom.homenet_bridge.yaml`에서는 두 개의 조명을 한 패킷에서 제어합니다. 람다에서 다른 채널 상태를 읽어 함께 전송해 일관성을 유지합니다.
+
+```yaml
+light:
+  - id: room_0_light_1
+    name: "Room 0 Light 1"
+    state:
+      data: [0x30, 0xd0, 0x00, 0x0e, 0x00]
+      mask: [0xff, 0xf0, 0xff, 0xff, 0xff]
+    state_on:
+      offset: 8
+      data: [0xff]
+    state_off:
+      offset: 8
+      data: [0x00]
+    command_on: !lambda |-
+      const light2 = getEntityState('room_0_light_2');
+      const light2_on = light2 && light2.is_on ? 0xff : 0x00;
+      return [[0x30, 0xbc, 0x00, 0x0e, 0x00, 0x01, 0x00, 0x00, 0xff, light2_on, 0, 0, 0, 0, 0, 0], [0x30, 0xdc]];
+    command_off: !lambda |-
+      const light2 = getEntityState('room_0_light_2');
+      const light2_on = light2 && light2.is_on ? 0xff : 0x00;
+      return [[0x30, 0xbc, 0x00, 0x0e, 0x00, 0x01, 0x00, 0x00, 0x00, light2_on, 0, 0, 0, 0, 0, 0], [0x30, 0xdc]];
+```
+
+## 작성 체크리스트
+1. 다채널 장비는 `mask`로 채널 비트를 고정한 뒤 `offset`만 변경해 재사용합니다.
+2. 조명 그룹을 동시에 전송해야 하면 `command_on/off` 안에 여러 패킷 배열을 반환하거나, 람다에서 다른 엔티티 상태를 읽어 일관성을 맞춥니다.
+3. 상태 패킷 길이가 길 경우 오프셋을 헷갈리기 쉬우니 주석으로 바이트 인덱스를 명시합니다.

--- a/docs/config-schema/lock.md
+++ b/docs/config-schema/lock.md
@@ -1,0 +1,69 @@
+# Lock 스키마 작성법
+
+도어락처럼 잠금/해제를 제어하는 장치는 `lock` 엔티티로 정의합니다.
+
+## 필수 필드
+- `id`, `name`
+- `state`: 상태 패킷 서명.
+- `state_locked`, `state_unlocked`: 현재 잠금 상태 판단용 패턴.
+- `command_lock`, `command_unlock`: 잠금/해제 명령 패킷.
+
+## 옵션 필드
+- `state_locking`, `state_unlocking`, `state_jammed`: 중간 상태나 오류 상태를 표현.
+- `command_update`: 상태 새로고침 패킷.
+
+## 기본 예제 (단순 잠금/해제)
+`kocom_theart.homenet_bridge.yaml`에서는 현관 도어락을 1바이트 상태로 판별합니다.
+
+```yaml
+lock:
+  - id: entrance_door
+    name: "현관 도어락"
+    state:
+      data: [0xaa, 0x55, 0x70, 0x00, 0x00]
+    state_locked:
+      offset: 8
+      data: [0x01]
+    state_unlocked:
+      offset: 8
+      data: [0x00]
+    command_lock:
+      data: [0xaa, 0x70, 0x01]
+    command_unlock:
+      data: [0xaa, 0x70, 0x00]
+```
+
+## 고급 예제 (중간 상태 추적)
+`ENTITY_EXAMPLES.md`에서 제안하는 확장 형태처럼, 추가 상태를 매핑하면 Home Assistant가 애니메이션을 표시합니다. 실제 패킷 비트에 맞춰 오프셋만 조정하세요.
+
+```yaml
+lock:
+  - id: entrance_gate
+    name: "출입문"
+    state:
+      data: [0xa1, 0x00]
+    state_locked:
+      offset: 1
+      data: [0x01]
+    state_unlocked:
+      offset: 1
+      data: [0x00]
+    state_locking:
+      offset: 1
+      data: [0x02]
+    state_unlocking:
+      offset: 1
+      data: [0x03]
+    state_jammed:
+      offset: 1
+      data: [0xff]
+    command_lock:
+      data: [0xa1, 0x01]
+    command_unlock:
+      data: [0xa1, 0x00]
+```
+
+## 작성 체크리스트
+1. 잠금 상태가 동일 패킷에서 여러 비트로 표현된다면 `mask`로 필요한 비트만 추출합니다.
+2. 도어락이 ACK 패킷을 별도로 보내면 `command_*`에 응답용 `rx_match`를 추가해 통신 성공 여부를 확인합니다.
+3. 실제 장치가 잠금/해제 중에 다른 값을 보내는지 캡쳐해 `state_locking`/`state_unlocking`을 넣으면 UX가 개선됩니다.

--- a/docs/config-schema/packet-defaults.md
+++ b/docs/config-schema/packet-defaults.md
@@ -1,0 +1,75 @@
+# Packet Defaults 스키마 작성법
+
+`homenet_bridge.packet_defaults`는 모든 엔티티가 공통으로 사용하는 패킷 프레임 규칙과 시간 제어 값을 정의합니다. 헤더/푸터, 체크섬, 타임아웃을 한 번에 지정해 중복을 줄이고, 개별 엔티티 블록에서 필요할 때만 오버라이드합니다.
+
+## 필수 필드
+- `rx_timeout`: 상태 패킷 수신 대기 시간. `10ms`처럼 시간 단위 문자열을 권장합니다.
+- `tx_timeout`: 명령 패킷 송신 완료까지 기다리는 최대 시간.
+- `tx_delay`: 연속 송신 시 두 패킷 사이의 지연.
+- `tx_retry_cnt`: 재전송 횟수.
+- `rx_header` / `tx_header`: 수신·송신 패킷 앞부분 식별 바이트 배열.
+- `rx_checksum` / `tx_checksum`: 기본 체크섬 계산기. `add_no_header`, `samsung_rx` 등 사전 정의된 이름을 사용합니다.
+
+## 옵션 필드
+- `rx_footer` / `tx_footer`: 패킷 종료 시그널이 있는 프로토콜에서 사용.
+- `rx_checksum2` / `tx_checksum2`: 보조 체크섬이 필요한 경우(예: XOR + 합산 이중 계산).
+
+## 기본 예제 (양방향 동일 헤더/푸터)
+`kocom.homenet_bridge.yaml`은 동일한 헤더·푸터와 단순 합산 체크섬을 사용합니다.
+
+```yaml
+homenet_bridge:
+  packet_defaults:
+    rx_timeout: 10ms
+    tx_delay: 50ms
+    tx_timeout: 500ms
+    tx_retry_cnt: 3
+    rx_header: [0xAA, 0x55]
+    rx_footer: [0x0D, 0x0D]
+    tx_header: [0xAA, 0x55]
+    tx_footer: [0x0D, 0x0D]
+    rx_checksum: add_no_header
+    tx_checksum: add_no_header
+```
+
+## 방향별 헤더/체크섬이 다른 예제
+`cvnet.homenet_bridge.yaml`처럼 수신·송신 헤더가 같더라도 푸터와 체크섬 로직이 다를 수 있습니다.
+
+```yaml
+homenet_bridge:
+  packet_defaults:
+    rx_header: [0xF7]
+    rx_footer: [0xAA]
+    rx_checksum: add_no_header
+    tx_header: [0xF7]
+    tx_footer: [0xAA]
+    tx_checksum: add_no_header
+```
+
+## 이중 체크섬 예제
+`ezville.homenet_bridge.yaml`은 XOR+합산 방식의 보조 체크섬을 사용합니다. 기본 체크섬이 없을 때 `rx_checksum`를 생략하고 `rx_checksum2`만 둘 수도 있습니다.
+
+```yaml
+homenet_bridge:
+  packet_defaults:
+    rx_header: [0xF7]
+    tx_header: [0xF7]
+    rx_checksum2: xor_add
+    tx_checksum2: xor_add
+```
+
+## 브랜드별 커스텀 계산기 예제
+`samsung_sds.homenet_bridge.yaml`은 전용 체크섬 함수를 사용합니다. 이름만 바꾸면 다른 엔티티가 자동으로 상속합니다.
+
+```yaml
+homenet_bridge:
+  packet_defaults:
+    rx_header: [0xB0]
+    rx_checksum: samsung_rx
+    tx_checksum: samsung_tx
+```
+
+## 작성 팁
+1. 헤더/푸터와 체크섬 계산 규칙을 모르면 우선 패킷 캡처를 진행한 뒤, 동일한 구간을 `state.data`로 맞춰 넣으세요.
+2. 엔티티마다 특이 규칙이 있을 경우 해당 엔티티 블록 안에 `packet_defaults`를 중첩해 일부 값만 덮어쓰면 됩니다.
+3. 타임아웃과 지연은 장비 응답 속도에 맞춰 조정하되, 과도하게 짧으면 재전송이 반복되고 길면 UI 반응이 느려집니다.

--- a/docs/config-schema/sensor.md
+++ b/docs/config-schema/sensor.md
@@ -1,0 +1,54 @@
+# Sensor 스키마 작성법
+
+전력, 온도, 습도 등 수치 데이터를 노출할 때는 `sensor` 엔티티를 사용합니다.
+
+## 필수 필드
+- `id`, `name`
+- `state`: 패킷 서명.
+- `state_value`: 센서 값 위치. `offset`, `length`, `precision`, `endian`을 설정합니다.
+
+## 옵션 필드
+- `device_class`, `unit_of_measurement`: Home Assistant 표현을 위한 단위/클래스.
+- `icon`: 커스텀 아이콘.
+- `filters`: 값 보정(`multiply`, `add`)이 필요할 때 사용.
+
+## 기본 예제 (전력 측정)
+`hyundai_imazu.homenet_bridge.yaml`에서는 실시간 전력량을 2바이트 정수로 읽습니다.
+
+```yaml
+sensor:
+  - id: power_usage_w
+    name: "전력 사용량"
+    device_class: power
+    unit_of_measurement: W
+    state:
+      data: [0x6f, 0x01, 0x02, 0x00, 0x00]
+    state_value:
+      offset: 8
+      length: 2
+      endian: big
+```
+
+## 필터 예제 (소수점 보정)
+`ezville.homenet_bridge.yaml`에서는 일부 값이 0.1 단위로 제공되어 `precision`과 `filters`를 함께 사용합니다.
+
+```yaml
+sensor:
+  - id: floor_temperature
+    name: "바닥 온도"
+    device_class: temperature
+    unit_of_measurement: "°C"
+    state:
+      data: [0x0d, 0x10, 0x01, 0x00, 0x00]
+    state_value:
+      offset: 10
+      length: 1
+      precision: 1
+    filters:
+      - multiply: 0.5
+```
+
+## 작성 체크리스트
+1. 센서 값이 부호 있는 정수인지 확인하고 필요하면 `signed: true`를 추가합니다.
+2. 길이가 2바이트 이상이면 `endian`을 지정하지 않을 때 기본은 big endian임을 기억하세요.
+3. 값이 비트 필드일 경우 `mask`를 사용하거나 `mapping`을 통해 텍스트 센서로 분리하는 것이 더 적절한지 검토합니다.

--- a/docs/config-schema/serial.md
+++ b/docs/config-schema/serial.md
@@ -1,0 +1,38 @@
+# Serial 설정 스키마 작성법
+
+`homenet_bridge.serial` 블록은 RS485 어댑터와의 기본 통신 파라미터를 정의합니다. 모든 엔티티 설정 전에 1회만 선언하며, 실제 장비 사양과 동일해야 합니다.
+
+## 필수 필드
+- `baud_rate`: 통신 속도(bps). 보통 9600/19200/38400 등.
+- `data_bits`: 데이터 비트 길이. 대부분 8.
+- `parity`: 패리티 검사 방식. `NONE`, `EVEN`, `ODD` 중 하나.
+- `stop_bits`: 스톱 비트 개수. 일반적으로 1.
+
+## 기본 예제 (8N1)
+`cvnet.homenet_bridge.yaml`처럼 9600bps, 패리티 없는 8N1 조합입니다.
+
+```yaml
+homenet_bridge:
+  serial:
+    baud_rate: 9600
+    data_bits: 8
+    parity: NONE
+    stop_bits: 1
+```
+
+## 패리티가 필요한 장비 예제
+`samsung_sds.homenet_bridge.yaml`은 짝수 패리티를 사용합니다. 기기 스펙에 맞춰 값만 교체하면 됩니다.
+
+```yaml
+homenet_bridge:
+  serial:
+    baud_rate: 9600
+    data_bits: 8
+    parity: EVEN
+    stop_bits: 1
+```
+
+## 작성 팁
+1. 제조사 매뉴얼의 UART/RS485 설정을 그대로 입력하세요. 한 자리라도 다르면 수신 패킷 매칭이 실패합니다.
+2. 같은 브랜드라도 도어락·인터폰이 다른 설정을 요구할 수 있으니, 각 프로파일을 별도 파일로 관리하세요.
+3. 포트 경로는 실행 시 환경 변수(`SERIAL_PORT`)나 CLI 옵션으로 주입하므로 스키마에는 포함하지 않습니다.

--- a/docs/config-schema/switch.md
+++ b/docs/config-schema/switch.md
@@ -1,0 +1,63 @@
+# Switch 스키마 작성법
+
+전원이나 모드 토글처럼 단순 On/Off 제어는 `switch` 엔티티로 정의합니다.
+
+## 필수 필드
+- `id`, `name`
+- `state`: 상태 패킷 서명.
+- `state_on`, `state_off`: 전원 상태 판단용 패턴.
+- `command_on`, `command_off`: 제어 패킷.
+
+## 옵션 필드
+- `icon`, `device_class`: UI 표시용 설정.
+- `state_delay`: 중복 이벤트 필터링.
+- `packet_defaults`: 특정 스위치의 헤더/체크섬 오버라이드.
+
+## 기본 예제 (콘센트 스위치)
+`hyundai_imazu.homenet_bridge.yaml`에서는 콘센트 스위치를 아래와 같이 정의합니다.
+
+```yaml
+switch:
+  - id: outlet_1
+    name: "콘센트 1"
+    icon: mdi:power-socket
+    state:
+      data: [0x6f, 0x01, 0x01, 0x00, 0x00]
+    state_on:
+      offset: 8
+      data: [0x01]
+    state_off:
+      offset: 8
+      data: [0x00]
+    command_on:
+      data: [0x6f, 0x81, 0x01, 0x01]
+    command_off:
+      data: [0x6f, 0x81, 0x01, 0x00]
+```
+
+## 고급 예제 (도어폰 호출 제어)
+`hyundai_door.homenet_bridge.yaml`에서는 도어폰 호출을 스위치로 표현하고, `state_delay`로 중복 호출을 줄입니다.
+
+```yaml
+switch:
+  - id: lobby_call
+    name: "공동현관 호출"
+    state:
+      data: [0x7f, 0x00, 0x00, 0x00, 0x00]
+    state_on:
+      offset: 1
+      data: [0x01]
+    state_off:
+      offset: 1
+      data: [0x00]
+    state_delay: 3s
+    command_on:
+      data: [0x7f, 0x81, 0x01]
+    command_off:
+      data: [0x7f, 0x81, 0x00]
+```
+
+## 작성 체크리스트
+1. 스위치 상태가 `mask`를 필요로 하는 경우가 많으니 패킷 덤프를 보고 필요한 비트만 잡아냅니다.
+2. 스위치가 순간동작(예: 리모컨 호출)이라면 `state_delay`를 짧게 두어 튀는 값을 방지합니다.
+3. 동일한 `state` 서명을 공유하는 여러 스위치가 있으면 `data` 내 장치 인덱스(예: `0x01`, `0x02`)를 주석으로 관리하세요.

--- a/docs/config-schema/text-sensor.md
+++ b/docs/config-schema/text-sensor.md
@@ -1,0 +1,48 @@
+# Text Sensor 스키마 작성법
+
+문자열 데이터(예: 도어폰 메시지, 상태 코드)를 전송할 때는 `text_sensor` 엔티티를 사용합니다.
+
+## 필수 필드
+- `id`, `name`
+- `state`: 패킷 서명.
+- `state_text`: 문자열을 읽을 위치. `offset`과 `length` 지정.
+
+## 옵션 필드
+- `encoding`: 기본 UTF-8 외 다른 인코딩이 필요할 때 설정.
+- `filters`: 문자열 치환(`replace`) 등에 사용.
+
+## 기본 예제 (문자 센서)
+`samsung_sds_door.homenet_bridge.yaml`에서는 도어폰 상태 문자열을 그대로 노출합니다.
+
+```yaml
+text_sensor:
+  - id: door_status
+    name: "도어폰 상태"
+    state:
+      data: [0x7f, 0x00, 0x00, 0x00]
+    state_text:
+      offset: 4
+      length: 8
+```
+
+## 매핑 예제 (상태 코드 → 문자열)
+`kocom_thinks.homenet_bridge.yaml`처럼 코드값을 사람이 읽기 쉬운 텍스트로 변환하려면 `mapping`을 사용합니다.
+
+```yaml
+text_sensor:
+  - id: valve_state_text
+    name: "밸브 상태 텍스트"
+    state:
+      data: [0x30, 0xd0, 0x00, 0x5b, 0x00]
+    state_text:
+      offset: 8
+      mapping:
+        0x00: "닫힘"
+        0x01: "열림"
+        0x02: "오류"
+```
+
+## 작성 체크리스트
+1. 텍스트 길이가 가변이면 `length` 대신 `until` 옵션으로 종료 바이트(예: `0x00`)를 지정합니다.
+2. 장치가 EUC-KR 등 다른 인코딩을 사용하면 `encoding`을 맞춰야 글자가 깨지지 않습니다.
+3. 숫자 코드를 문자열로 바꿀 수 있다면 `mapping`이 더 간결하며, Home Assistant 자동화에서도 편리합니다.

--- a/docs/config-schema/valve.md
+++ b/docs/config-schema/valve.md
@@ -1,0 +1,69 @@
+# Valve 스키마 작성법
+
+가스 밸브나 온수 밸브처럼 열림/닫힘을 제어하는 장치는 `valve` 엔티티로 정의합니다.
+
+## 필수 필드
+- `id`, `name`
+- `state`: 상태 패킷 서명.
+- `state_open`, `state_closed`: 밸브 상태 판별.
+- `command_open`, `command_close`: 제어 패킷.
+
+## 옵션 필드
+- `command_stop`: 열림/닫힘 중지 명령.
+- `state_opening`, `state_closing`: 진행 중 상태 표현.
+- `command_update`: 상태 재요청.
+
+## 기본 예제 (가스 밸브)
+`commax.homenet_bridge.yaml`은 단일 바이트로 열림/닫힘을 구분합니다.
+
+```yaml
+valve:
+  - id: gas_valve
+    name: "가스 밸브"
+    state:
+      data: [0xf7, 0x02, 0x26, 0x00, 0x00]
+    state_open:
+      offset: 8
+      data: [0x00]
+    state_closed:
+      offset: 8
+      data: [0x01]
+    command_open:
+      data: [0xaa, 0x26, 0x00]
+    command_close:
+      data: [0xaa, 0x26, 0x01]
+```
+
+## 확장 예제 (업데이트/중간 상태)
+`kocom.homenet_bridge.yaml`에서는 업데이트 요청과 진행 상태를 함께 정의합니다.
+
+```yaml
+valve:
+  - id: gas_valve
+    name: "가스 밸브"
+    state:
+      data: [0x30, 0xd0, 0x00, 0x5b, 0x00]
+    state_open:
+      offset: 8
+      data: [0x00]
+    state_closed:
+      offset: 8
+      data: [0x01]
+    state_opening:
+      offset: 8
+      data: [0x02]
+    state_closing:
+      offset: 8
+      data: [0x03]
+    command_open:
+      data: [0x30, 0xb7, 0x00, 0x5b, 0x00, 0x00]
+    command_close:
+      data: [0x30, 0xb7, 0x00, 0x5b, 0x00, 0x01]
+    command_update:
+      data: [0x30, 0xdc]
+```
+
+## 작성 체크리스트
+1. 밸브가 물리적으로 움직이는 시간이 길다면 `state_opening`/`state_closing`을 설정해 사용자가 진행 상황을 알 수 있게 합니다.
+2. 안전을 위해 `command_stop`이 지원되는지 확인하고, 지원한다면 별도 버튼이나 자동화에 연동하세요.
+3. 가스 밸브처럼 치명적 제어인 경우 MQTT 주제를 별도로 분리하거나 인증을 강화하는 것을 권장합니다.


### PR DESCRIPTION
## Summary
- document homenet_bridge serial configuration with field guidance and examples
- add packet_defaults schema guide covering headers, checksums, and timeouts
- update config schema index to link the new top-level configuration docs

## Testing
- Not run (documentation changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69339e7aec78832ca4358a614d1502ab)