### PR TITLE
Add configuration validation and surface errors

### DIFF
--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -4,21 +4,9 @@ import { logger } from '../utils/logger.js';
 import { parseDuration } from '../utils/duration.js';
 import { ENTITY_TYPE_KEYS } from '../utils/entities.js';
 
-export async function loadConfig(configPath: string): Promise<HomenetBridgeConfig> {
-  logger.info(`[core] Loading configuration from: ${configPath}`);
-  const loadedYaml = await loadYamlConfig(configPath);
-
-  if (!loadedYaml || !(loadedYaml as any).homenet_bridge) {
-    throw new Error(
-      'Invalid configuration file structure. Missing "homenet_bridge" top-level key.',
-    );
-  }
-
-  const loadedConfig = (loadedYaml as any).homenet_bridge as HomenetBridgeConfig;
-
-  // Normalize packet_defaults duration values
-  if (loadedConfig.packet_defaults) {
-    const pd = loadedConfig.packet_defaults;
+export function normalizeConfig(config: HomenetBridgeConfig) {
+  if (config.packet_defaults) {
+    const pd = config.packet_defaults;
     if (pd.rx_timeout !== undefined) {
       pd.rx_timeout = parseDuration(pd.rx_timeout as any);
     }
@@ -31,11 +19,93 @@ export async function loadConfig(configPath: string): Promise<HomenetBridgeConfi
     logger.debug({ packet_defaults: pd }, '[config] Normalized packet_defaults');
   }
 
-  const hasEntities = ENTITY_TYPE_KEYS.some((type) => loadedConfig[type] && Array.isArray(loadedConfig[type]));
+  if (config.serial?.parity) {
+    config.serial.parity = config.serial.parity.toString().toLowerCase() as HomenetBridgeConfig['serial']['parity'];
+  }
+
+  return config;
+}
+
+export function validateConfig(config: HomenetBridgeConfig): void {
+  const errors: string[] = [];
+
+  if (!config.serial) {
+    errors.push('serial 설정이 누락되었습니다.');
+  } else {
+    const { baud_rate, data_bits, parity, stop_bits } = config.serial;
+    const allowedDataBits = [5, 6, 7, 8];
+    const allowedParity = ['none', 'even', 'mark', 'odd', 'space'];
+    const allowedStopBits = [1, 1.5, 2];
+
+    if (typeof baud_rate !== 'number' || Number.isNaN(baud_rate)) {
+      errors.push('serial.baud_rate는 숫자여야 합니다.');
+    }
+    if (!allowedDataBits.includes(data_bits)) {
+      errors.push(`serial.data_bits는 ${allowedDataBits.join(', ')} 중 하나여야 합니다.`);
+    }
+    if (!allowedParity.includes(parity as string)) {
+      errors.push(`serial.parity는 ${allowedParity.join(', ')} 중 하나여야 합니다.`);
+    }
+    if (!allowedStopBits.includes(stop_bits)) {
+      errors.push(`serial.stop_bits는 ${allowedStopBits.join(', ')} 중 하나여야 합니다.`);
+    }
+  }
+
+  if (config.packet_defaults) {
+    const { rx_checksum, rx_checksum2, tx_checksum, tx_checksum2 } = config.packet_defaults;
+    if (rx_checksum && rx_checksum2) {
+      errors.push('packet_defaults에서 rx_checksum과 rx_checksum2는 동시에 설정할 수 없습니다.');
+    }
+    if (tx_checksum && tx_checksum2) {
+      errors.push('packet_defaults에서 tx_checksum과 tx_checksum2는 동시에 설정할 수 없습니다.');
+    }
+  }
+
+  const hasEntities = ENTITY_TYPE_KEYS.some((type) => config[type] && Array.isArray(config[type]) && (config[type] as any[]).length > 0);
 
   if (!hasEntities) {
-    throw new Error('Configuration file must contain at least one entity (e.g., light, climate).');
+    errors.push('최소 한 개 이상의 엔터티(light, climate 등)가 설정되어야 합니다.');
   }
+
+  ENTITY_TYPE_KEYS.forEach((type) => {
+    const entities = config[type] as Array<Record<string, unknown>> | undefined;
+    if (!entities) return;
+
+    if (!Array.isArray(entities)) {
+      errors.push(`${String(type)} 항목은 배열이어야 합니다.`);
+      return;
+    }
+
+    entities.forEach((entity, index) => {
+      if (!entity || typeof entity !== 'object') {
+        errors.push(`${String(type)}[${index}]는 객체여야 합니다.`);
+        return;
+      }
+
+      if (!('id' in entity) || typeof entity.id !== 'string' || !entity.id.trim()) {
+        errors.push(`${String(type)}[${index}]에 유효한 id(문자열)가 필요합니다.`);
+      }
+    });
+  });
+
+  if (errors.length > 0) {
+    throw new Error(`설정 검증에 실패했습니다:\n- ${errors.join('\n- ')}`);
+  }
+}
+
+export async function loadConfig(configPath: string): Promise<HomenetBridgeConfig> {
+  logger.info(`[core] Loading configuration from: ${configPath}`);
+  const loadedYaml = await loadYamlConfig(configPath);
+
+  if (!loadedYaml || !(loadedYaml as any).homenet_bridge) {
+    throw new Error(
+      'Invalid configuration file structure. Missing "homenet_bridge" top-level key.',
+    );
+  }
+
+  const loadedConfig = normalizeConfig((loadedYaml as any).homenet_bridge as HomenetBridgeConfig);
+
+  validateConfig(loadedConfig);
 
   return loadedConfig;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,10 +7,21 @@ import { eventBus } from './service/event-bus.js';
 import type { HomenetBridgeConfig, LambdaConfig } from './config/types.js';
 import { CommandGenerator } from './protocol/generators/command.generator.js';
 import type { EntityConfig } from './domain/entities/base.entity.js';
+import { normalizeConfig, validateConfig } from './config/index.js';
 
 dotenv.config();
 
-export { HomeNetBridge, BridgeOptions, logger, eventBus, HomenetBridgeConfig, LambdaConfig, CommandGenerator };
+export {
+  HomeNetBridge,
+  BridgeOptions,
+  logger,
+  eventBus,
+  HomenetBridgeConfig,
+  LambdaConfig,
+  CommandGenerator,
+  normalizeConfig,
+  validateConfig,
+};
 export type { EntityConfig };
 
 export async function createBridge(

--- a/packages/service/src/server.ts
+++ b/packages/service/src/server.ts
@@ -13,6 +13,8 @@ import {
   logger,
   eventBus,
   LambdaConfig,
+  normalizeConfig,
+  validateConfig,
 } from '@rs485-homenet/core';
 import { PacketCache } from './cache.js';
 
@@ -426,7 +428,9 @@ async function loadAndStartBridge(filename: string) {
     }
 
     currentConfigFile = filename;
-    currentConfigContent = loadedYaml.homenet_bridge; // Store the actual homenet_bridge config
+    currentConfigContent = normalizeConfig(loadedYaml.homenet_bridge); // Store the normalized config
+
+    validateConfig(currentConfigContent);
 
     const mqttUrl = process.env.MQTT_URL?.trim() || 'mqtt://mq:1883';
     const mqttUsername = process.env.MQTT_USER?.trim() || undefined;


### PR DESCRIPTION
## Summary
- normalize and validate bridge configuration, enforcing required serial fields and checksum exclusivity
- reuse shared validation/normalization when loading configs in the service to block startup on invalid files and expose messages
- export the validation helpers from the core package for other consumers

## Testing
- pnpm test --filter @rs485-homenet/core *(fails: pnpm unavailable in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69340e5ca5e0832cbab30467268248db)