### PR TITLE
Fix automation manager type imports

### DIFF
--- a/packages/core/src/automation/automation-manager.ts
+++ b/packages/core/src/automation/automation-manager.ts
@@ -1,7 +1,7 @@
 import parser from 'cron-parser';
 import { EventEmitter } from 'node:events';
 
-import {
+import type {
   AutomationAction,
   AutomationActionCommand,
   AutomationActionDelay,


### PR DESCRIPTION
## Summary
- change automation manager to import configuration types using `import type` to satisfy NodeNext module requirements

## Testing
- pnpm --filter @rs485-homenet/core build *(fails: pnpm not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69345374a8cc832cab4329de9b101e56)