### PR TITLE
Fix serial config typing for build

### DIFF
--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -76,7 +76,7 @@ export function normalizeConfig(config: HomenetBridgeConfig) {
     config.serials = [normalizedSerial];
   } else {
     // 비정상 입력을 대비해 기본 구조만 유지하고, 검증 단계에서 에러를 던집니다.
-    config.serials = [] as unknown as [SerialConfig];
+    config.serials = [];
   }
 
   return config;

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -125,7 +125,7 @@ export interface HomenetBridgeConfig {
    */
   serial: SerialConfig;
   /** @deprecated 입력에서는 허용되지 않으며 normalize 과정에서 채워집니다. */
-  serials: [SerialConfig];
+  serials: SerialConfig[];
   devices?: DeviceConfig[];
   light?: LightEntity[];
   climate?: ClimateEntity[];


### PR DESCRIPTION
## Summary
- update HomenetBridgeConfig serials typing to use arrays and normalize empty defaults
- add persistable config helper in service to drop deprecated serials key while satisfying type checks
- ensure service normalization casts use full config typing

## Testing
- pnpm test
- pnpm build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bdfa69988832ca340301271933feb)