### PR TITLE
feat: ensure version bump commit follows build

### DIFF
--- a/.github/workflows/deploy-addon.yml
+++ b/.github/workflows/deploy-addon.yml
@@ -26,46 +26,39 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Bump version
-        id: bump_version
-        if: ${{ github.event.inputs.increment != 'none' }}
+      - name: Prepare version
+        id: get_version
         run: |
           # Read current version from config.yaml
           CURRENT_VERSION=$(grep '^version:' hassio-addon/config.yaml | awk '{print $2}' | tr -d '"' | tr -d '\r' | xargs)
           IFS='.' read -r major minor patch <<< "$CURRENT_VERSION"
 
           INCREMENT="${{ github.event.inputs.increment }}"
+          NEW_VERSION="$CURRENT_VERSION"
 
           if [ "$INCREMENT" == "major" ]; then
             major=$((major + 1))
             minor=0
             patch=0
+            NEW_VERSION="$major.$minor.$patch"
           elif [ "$INCREMENT" == "minor" ]; then
             minor=$((minor + 1))
             patch=0
+            NEW_VERSION="$major.$minor.$patch"
           elif [ "$INCREMENT" == "patch" ]; then
             patch=$((patch + 1))
+            NEW_VERSION="$major.$minor.$patch"
           fi
 
-          NEW_VERSION="$major.$minor.$patch"
-          echo "Bumping version from $CURRENT_VERSION to $NEW_VERSION"
+          echo "Current version: $CURRENT_VERSION"
+          echo "Target version: $NEW_VERSION"
 
-          # Update config.yaml
-          sed -i "s/^version: .*/version: $NEW_VERSION/" hassio-addon/config.yaml
+          if [ "$INCREMENT" != "none" ]; then
+             echo "Updating config.yaml to $NEW_VERSION"
+             sed -i "s/^version: .*/version: $NEW_VERSION/" hassio-addon/config.yaml
+          fi
 
-          # Commit and push
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add hassio-addon/config.yaml
-          git commit -m "chore: bump addon version to $NEW_VERSION"
-          git push origin HEAD:${{ github.ref }}
-
-      - name: Get version
-        id: get_version
-        run: |
-          # Read again to get the bumped version (or existing if none)
-          VERSION=$(grep '^version:' hassio-addon/config.yaml | awk '{print $2}' | tr -d '"' | tr -d '\r' | xargs)
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -106,6 +99,18 @@ jobs:
             nubiz/homenet2mqtt:latest
             nubiz/homenet2mqtt:${{ steps.get_version.outputs.VERSION }}
 
+      - name: Commit and Push Version
+        if: ${{ github.event.inputs.increment != 'none' && steps.check_image.outputs.exists != 'true' }}
+        run: |
+          NEW_VERSION="${{ steps.get_version.outputs.VERSION }}"
+          echo "Committing version bump to $NEW_VERSION"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add hassio-addon/config.yaml
+          git commit -m "chore: bump addon version to $NEW_VERSION"
+          git push origin HEAD:${{ github.ref }}
+
   sync-addon-repo:
     needs: build
     runs-on: ubuntu-latest
@@ -115,7 +120,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: source
-          ref: ${{ github.ref }} # Checkout the latest commit (including version bump)
+          ref: ${{ github.ref }} # Checkout the latest commit (including version bump if applicable)
 
       - name: Checkout Target Repo
         uses: actions/checkout@v4


### PR DESCRIPTION
- Modified `.github/workflows/deploy-addon.yml` to trigger only on `workflow_dispatch`.
- Combined version preparation into a pre-build step that updates `config.yaml` locally but does not commit.
- Moved the commit and push of the version bump to a step *after* the build and push steps.
- Ensured `sync-addon-repo` job checks out the specific ref pushed by the build job.
- This ensures that if the build fails, the version bump is not committed to the repository, while still allowing the build to use the new version tag.