### PR TITLE
Add serial path test flow to setup wizard

### DIFF
--- a/packages/service/tsconfig.json
+++ b/packages/service/tsconfig.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
-    "declaration": false
+    "declaration": false,
+    "paths": {
+      "@rs485-homenet/core": ["../core/src/index.ts"],
+      "@rs485-homenet/core/*": ["../core/src/*"]
+    }
   },
   "include": ["src/**/*"]
 }

--- a/packages/ui/src/lib/components/SetupWizard.svelte
+++ b/packages/ui/src/lib/components/SetupWizard.svelte
@@ -12,6 +12,10 @@
   let submitting = $state(false);
   let consentSubmitting = $state(false);
   let error = $state('');
+  let testingSerial = $state(false);
+  let testError = $state('');
+  let testPackets = $state<string[]>([]);
+  let hasTested = $state(false);
   let currentStep = $state<WizardStep>('config');
   let currentLocale = $state('ko');
 
@@ -32,6 +36,15 @@
   // Load examples on mount
   $effect(() => {
     loadExamples();
+  });
+
+  // Reset test result when input changes
+  $effect(() => {
+    serialPath;
+    selectedExample;
+    testError = '';
+    testPackets = [];
+    hasTested = false;
   });
 
   async function loadExamples() {
@@ -107,6 +120,49 @@
       error = $t('setup_wizard.submit_error');
     } finally {
       submitting = false;
+    }
+  }
+
+  async function handleSerialTest() {
+    if (!selectedExample || !serialPath.trim()) {
+      testError = $t('setup_wizard.validation_error');
+      return;
+    }
+
+    testingSerial = true;
+    testError = '';
+    hasTested = true;
+    testPackets = [];
+
+    try {
+      const res = await fetch('./api/config/examples/test-serial', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          filename: selectedExample,
+          serialPath: serialPath.trim(),
+        }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        const errorKey = data.error || 'UNKNOWN_ERROR';
+        testError = $t(`errors.${errorKey}`, {
+          default: data.error || $t('setup_wizard.serial_test_error'),
+        });
+        return;
+      }
+
+      testPackets = Array.isArray(data.packets) ? data.packets : [];
+
+      if (testPackets.length === 0) {
+        testError = $t('setup_wizard.serial_test_empty');
+      }
+    } catch (err) {
+      testError = $t('setup_wizard.serial_test_error');
+    } finally {
+      testingSerial = false;
     }
   }
 
@@ -195,6 +251,44 @@
             disabled={submitting}
           />
           <p class="field-hint">{$t('setup_wizard.serial_path_hint')}</p>
+          <div class="test-actions">
+            <button
+              type="button"
+              class="secondary-btn"
+              onclick={handleSerialTest}
+              disabled={
+                submitting ||
+                testingSerial ||
+                !selectedExample ||
+                !serialPath.trim()
+              }
+            >
+              {testingSerial
+                ? $t('setup_wizard.serial_test_running')
+                : $t('setup_wizard.serial_test_button')}
+            </button>
+            {#if testError}
+              <p class="field-hint error-hint">{testError}</p>
+            {/if}
+          </div>
+          {#if hasTested}
+            <div class="serial-test-result">
+              {#if testingSerial}
+                <p class="field-hint">{$t('setup_wizard.serial_test_wait')}</p>
+              {:else if testPackets.length > 0}
+                <div class="result-list">
+                  {#each testPackets as packet, index}
+                    <div class="result-row">
+                      <span class="badge">#{index + 1}</span>
+                      <code>{packet}</code>
+                    </div>
+                  {/each}
+                </div>
+              {:else if !testError}
+                <p class="field-hint muted">{$t('setup_wizard.serial_test_empty')}</p>
+              {/if}
+            </div>
+          {/if}
         </div>
 
         {#if error}
@@ -423,6 +517,61 @@
     font-size: 0.8rem;
     color: #94a3b8;
     margin: 0.5rem 0 0 0;
+  }
+
+  .test-actions {
+    margin-top: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .test-actions .secondary-btn {
+    align-self: flex-start;
+  }
+
+  .serial-test-result {
+    margin-top: 0.75rem;
+    padding: 0.75rem;
+    border-radius: 8px;
+    border: 1px solid rgba(148, 163, 184, 0.3);
+    background: rgba(15, 23, 42, 0.7);
+  }
+
+  .result-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .result-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: #e2e8f0;
+    font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+    word-break: break-all;
+  }
+
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.15rem 0.5rem;
+    border-radius: 9999px;
+    border: 1px solid rgba(59, 130, 246, 0.4);
+    background: rgba(59, 130, 246, 0.15);
+    color: #93c5fd;
+    font-weight: 700;
+    font-size: 0.8rem;
+  }
+
+  .error-hint {
+    color: #fca5a5;
+  }
+
+  .muted {
+    color: #94a3b8;
   }
 
   .error-message {

--- a/packages/ui/src/lib/i18n/locales/en.json
+++ b/packages/ui/src/lib/i18n/locales/en.json
@@ -206,7 +206,8 @@
     "SERIAL_PATH_REQUIRED": "Serial port path is required.",
     "EXAMPLE_NOT_FOUND": "Example configuration file not found.",
     "EXAMPLE_READ_FAILED": "Failed to read example configuration file.",
-    "SERIAL_CONFIG_MISSING": "Serial configuration is missing from the config file."
+    "SERIAL_CONFIG_MISSING": "Serial configuration is missing from the config file.",
+    "SERIAL_TEST_FAILED": "Failed to test the serial path."
   },
   "setup_wizard": {
     "title": "Initial Setup",
@@ -218,6 +219,11 @@
     "serial_path_label": "Serial Port Path",
     "serial_path_placeholder": "/dev/ttyUSB0 or 192.168.0.100:8899",
     "serial_path_hint": "Enter the RS485 device path or TCP address.",
+    "serial_test_button": "Test serial path",
+    "serial_test_running": "Testing serial path...",
+    "serial_test_wait": "Listening for raw packets...",
+    "serial_test_empty": "No raw packets received yet. Check the wiring or try again.",
+    "serial_test_error": "Failed to read from the serial path. Please try again.",
     "validation_error": "Please select an example and enter a serial port path.",
     "step_config": "Config",
     "step_consent": "Consent",

--- a/packages/ui/src/lib/i18n/locales/ko.json
+++ b/packages/ui/src/lib/i18n/locales/ko.json
@@ -206,7 +206,8 @@
     "SERIAL_PATH_REQUIRED": "시리얼 포트 경로를 입력해주세요.",
     "EXAMPLE_NOT_FOUND": "예제 설정 파일을 찾을 수 없습니다.",
     "EXAMPLE_READ_FAILED": "예제 설정 파일을 읽을 수 없습니다.",
-    "SERIAL_CONFIG_MISSING": "설정 파일에 serial 설정이 없습니다."
+    "SERIAL_CONFIG_MISSING": "설정 파일에 serial 설정이 없습니다.",
+    "SERIAL_TEST_FAILED": "시리얼 경로 테스트에 실패했습니다."
   },
   "setup_wizard": {
     "title": "초기 설정",
@@ -218,6 +219,11 @@
     "serial_path_label": "시리얼 포트 경로",
     "serial_path_placeholder": "/dev/ttyUSB0 또는 192.168.0.100:8899",
     "serial_path_hint": "RS485 장치 경로 또는 TCP 주소를 입력하세요.",
+    "serial_test_button": "시리얼 경로 테스트",
+    "serial_test_running": "시리얼 경로를 확인 중입니다...",
+    "serial_test_wait": "RAW 패킷을 수신하는 중입니다...",
+    "serial_test_empty": "아직 수신된 RAW 패킷이 없습니다. 배선을 확인하거나 다시 시도해주세요.",
+    "serial_test_error": "시리얼 경로를 읽는 데 실패했습니다. 다시 시도해주세요.",
     "validation_error": "예제와 시리얼 포트 경로를 모두 입력해주세요.",
     "step_config": "설정",
     "step_consent": "동의",


### PR DESCRIPTION
## Summary
- add a backend endpoint to probe example configs against a user-provided serial path and collect raw packets
- enhance the setup wizard with a serial path test button, inline results, and new i18n strings
- align service TypeScript resolution with core sources for linting
- rate-limit the serial path test API to prevent excessive port probes

## Testing
- pnpm build
- pnpm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944f529f6c4832c8079525fa71fac61)