### PR TITLE
Enable UART access for Home Assistant add-ons

### DIFF
--- a/hassio-addon-dev/config.yaml
+++ b/hassio-addon-dev/config.yaml
@@ -24,6 +24,7 @@ options:
   mqtt_topic_prefix: homenet2mqtt
 hassio_role: default
 hassio_api: true
+uart: true
 services:
   - mqtt:need
 schema:

--- a/hassio-addon/config.yaml
+++ b/hassio-addon/config.yaml
@@ -25,6 +25,7 @@ options:
   mqtt_topic_prefix: homenet2mqtt
 hassio_role: default
 hassio_api: true
+uart: true
 services:
   - mqtt:need
 schema:


### PR DESCRIPTION
## Summary
- enable UART access in both release and dev Home Assistant add-on configurations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69468fee3630832c9cb432cc2eee1015)