### PR TITLE
Fix Vitest alias for core package

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,23 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: '@rs485-homenet/core',
+        replacement: path.resolve(__dirname, 'packages/core/src/index.ts'),
+      },
+      {
+        find: /^@rs485-homenet\/core\/(.*)$/,
+        replacement: path.resolve(__dirname, 'packages/core/src/$1'),
+      },
+    ],
+  },
   test: {
     environment: 'node',
     include: ['packages/*/test/**/*.test.ts'],


### PR DESCRIPTION
## Summary
- keep Vitest mapping for `@rs485-homenet/core` pointed at the workspace source entry
- add a subpath alias so Vitest resolves `@rs485-homenet/core/*` imports against the source tree
- verify the workspace build completes after the alias update

## Testing
- `pnpm test -- packages/core/test/checksum2.test.ts`
- `pnpm build`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946c40ad7c0832c811c9768d09b1284)