### PR TITLE
feat: Support ack/mask hex formatting and robust dumping

### DIFF
--- a/packages/service/src/utils/yaml-dumper.ts
+++ b/packages/service/src/utils/yaml-dumper.ts
@@ -28,6 +28,10 @@ function markHex(obj: any): any {
     return obj.map(markHex);
   }
   if (obj && typeof obj === 'object') {
+    // Only traverse plain objects to avoid breaking Date, RegExp, etc.
+    if (obj.constructor !== Object) {
+      return obj;
+    }
     const newObj: Record<string, any> = {};
     for (const key in obj) {
       if (Object.prototype.hasOwnProperty.call(obj, key)) {
@@ -38,6 +42,8 @@ function markHex(obj: any): any {
             key.startsWith('command') ||
             key.includes('header') ||
             key.includes('footer') ||
+            key === 'ack' ||
+            key === 'mask' ||
             key === 'data') &&
           Array.isArray(value)
         ) {
@@ -75,8 +81,8 @@ export function dumpConfigToYaml(config: any, options: yaml.DumpOptions = {}): s
   const dump = yaml.dump(markedConfig, {
     schema: SCHEMA,
     noRefs: true,
-    lineWidth: -1,
     ...options,
+    lineWidth: -1, // Force infinite line width to ensure hex arrays are not wrapped, which would break the regex replacement
   });
 
   // Remove the !hexSeq tag and quotes around the flow array string


### PR DESCRIPTION
- Added `ack` and `mask` keys to the list of arrays formatted as hex flow style `[0xXX, ...]`.
- Updated `dumpConfigToYaml` to enforce `lineWidth: -1` (infinite width) regardless of options passed. This ensures that the generated hex array strings are never wrapped by `js-yaml`, which is critical for the regex post-processing (`.replace(...)`) to correctly strip tags and quotes.
- Hardened `markHex` recursion to only traverse plain objects (`obj.constructor === Object`), preventing corruption of special types like `Date` or `RegExp` during the deep copy process.