### PR TITLE
feat(core): add optimistic mode for switch entity

### DIFF
--- a/packages/core/src/protocol/device.ts
+++ b/packages/core/src/protocol/device.ts
@@ -12,7 +12,11 @@ export abstract class Device {
 
   public abstract parseData(packet: number[]): Record<string, any> | null;
 
-  public abstract constructCommand(commandName: string, value?: any): number[] | null;
+  public abstract constructCommand(
+    commandName: string,
+    value?: any,
+    states?: Map<string, Record<string, any>>,
+  ): number[] | null;
 
   public getOptimisticState(commandName: string, value?: any): Record<string, any> | null {
     return null;


### PR DESCRIPTION
- Add `optimistic` configuration option to `EntityConfig` and `DeviceConfig`
- Implement `getOptimisticState` in `SwitchDevice`
- Refactor `PacketProcessor` to use registered devices for command construction
- Update `MqttSubscriber` to handle virtual (empty) command packets gracefully
- Update `Device.constructCommand` signature to fix build error
- Update documentation in `docs/config-schema/`