### PR TITLE
엔티티 문서에 MQTT Discovery 메시지 구성 추가

### DIFF
--- a/docs/config-schema/binary-sensor.md
+++ b/docs/config-schema/binary-sensor.md
@@ -14,6 +14,18 @@
 2.  **CEL 방식**: `state_state` 필드를 사용합니다.
     - `state_state`: 패킷 데이터를 분석해 `'ON'` 또는 `'OFF'` 문자열을 반환하는 CEL 표현식입니다.
 
+## MQTT 디스커버리 메시지 구성
+- 토픽: `homeassistant/binary_sensor/<unique_id>/config`
+- 공통 필드
+  - `name`, `default_entity_id`, `unique_id`
+  - `state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
+  - `availability`: `${MQTT_TOPIC_PREFIX}/bridge/status`
+  - `device`: `devices` 설정 또는 브리지 기본 정보
+  - 선택: `suggested_area`, `device_class`, `unit_of_measurement`, `state_class`, `icon`
+- 바이너리 센서 전용
+  - `value_template`: `{{ value_json.state }}`
+  - 선택: `payload_on`, `payload_off` (설정 파일의 `payload_on/off` 값을 사용)
+
 ## 예제: 도어벨 패킷 매칭
 `hyundai_door.homenet_bridge.yaml`에서는 헤더·푸터를 전역으로 설정하고, 오프셋 0 바이트를 확인해 벨 상태를 판별합니다.【F:packages/core/config/hyundai_door.homenet_bridge.yaml†L17-L38】
 

--- a/docs/config-schema/button.md
+++ b/docs/config-schema/button.md
@@ -8,6 +8,18 @@
 ## 옵션 필드
 - 추가 필드는 없지만, `command_press`에 CEL 표현식을 사용해 다중 패킷 전송이나 동적 명령 생성을 구성할 수 있습니다. [CEL 가이드](../CEL_GUIDE.md)를 참고하세요.
 
+## MQTT 디스커버리 메시지 구성
+- 토픽: `homeassistant/button/<unique_id>/config`
+- 공통 필드
+  - `name`, `default_entity_id`, `unique_id`
+  - `state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state` (버튼은 상태를 쓰지 않지만 브리지에서 기본으로 포함)
+  - `availability`: `${MQTT_TOPIC_PREFIX}/bridge/status`
+  - `device`: `devices` 설정 또는 브리지 기본 정보
+  - 선택: `suggested_area`, `device_class`, `unit_of_measurement`, `state_class`, `icon`
+- 버튼 전용
+  - `command_topic`: `${MQTT_TOPIC_PREFIX}/${id}/set`
+  - `payload_press`: `PRESS`
+
 ## 예제: 공동 현관 문열림 명령
 `hyundai_door.homenet_bridge.yaml`은 두 가지 버튼을 정의하고, 고정 데이터 배열로 문열림 명령을 보냅니다.【F:packages/core/config/hyundai_door.homenet_bridge.yaml†L40-L51】
 

--- a/docs/config-schema/climate.md
+++ b/docs/config-schema/climate.md
@@ -55,6 +55,39 @@
 - **명령(`command_custom_*`)**: 사용자가 UI에서 선택한 문자열(`xstr`)을 인자로 받아 전송할 **바이트 배열**(`[0x01, ...]` 등)을 반환해야 합니다.
   - ⚠️ 문자열 비교 시 `x`가 아닌 **`xstr`** 변수를 사용합니다. (예: `xstr == "Turbo"`)
 
+## MQTT 디스커버리 메시지 구성
+- 토픽: `homeassistant/climate/<unique_id>/config`
+- 공통 필드
+  - `name`, `default_entity_id`, `unique_id`
+  - `state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
+  - `availability`: `${MQTT_TOPIC_PREFIX}/bridge/status`
+  - `device`: `devices` 설정 또는 브리지 기본 정보
+  - 선택: `suggested_area`, `device_class`, `unit_of_measurement`, `state_class`, `icon`
+- 모드/온도 제어
+  - `mode_command_topic`: `${MQTT_TOPIC_PREFIX}/${id}/mode/set`
+  - `temperature_command_topic`: `${MQTT_TOPIC_PREFIX}/${id}/temperature/set`
+  - `mode_state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
+  - `mode_state_template`: `{{ value_json.mode }}`
+  - `temperature_state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
+  - `temperature_state_template`: `{{ value_json.target_temperature }}`
+  - `current_temperature_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
+  - `current_temperature_template`: `{{ value_json.current_temperature }}`
+  - 선택: `action_topic` + `action_template` (설정에 `state_action`이 있을 때)
+- 가용 모드
+  - `modes`: `state_off/state_heat/state_cool/state_fan_only/state_dry/state_auto` 존재 여부로 목록 생성
+- 커스텀 팬/프리셋 모드
+  - `fan_modes`: `custom_fan_mode` 값 그대로 노출
+  - `fan_mode_command_topic`: `${MQTT_TOPIC_PREFIX}/${id}/fan_mode/set`
+  - `fan_mode_state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
+  - `fan_mode_state_template`: `{{ value_json.custom_fan }}`
+  - `preset_modes`: `custom_preset` 값 그대로 노출
+  - `preset_mode_command_topic`: `${MQTT_TOPIC_PREFIX}/${id}/preset_mode/set`
+  - `preset_mode_state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
+  - `preset_mode_state_template`: `{{ value_json.custom_preset }}`
+- 고정 값
+  - `temperature_unit`: `C`
+  - `min_temp`: `15`, `max_temp`: `30`, `temp_step`: `1`
+
 ## 예제: 온도·습도 설정
 `kocom_thinks.homenet_bridge.yaml`은 현재/목표 온도와 상태 비트를 분리해 읽고, `command_temperature`를 통해 온도를 설정합니다.【F:packages/core/config/examples/kocom_thinks.homenet_bridge.yaml†L601-L641】
 

--- a/docs/config-schema/fan.md
+++ b/docs/config-schema/fan.md
@@ -47,6 +47,36 @@ fan:
 - **명령(`command_preset_mode`)**: 사용자가 UI에서 선택한 문자열(`xstr`)을 인자로 받아 바이트 배열을 반환해야 합니다.
   - ⚠️ 문자열 비교 시 `x`가 아닌 **`xstr`** 변수를 사용합니다. (예: `xstr == "Turbo"`)
 
+## MQTT 디스커버리 메시지 구성
+- 토픽: `homeassistant/fan/<unique_id>/config`
+- 공통 필드
+  - `name`, `default_entity_id`, `unique_id`
+  - `state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
+  - `availability`: `${MQTT_TOPIC_PREFIX}/bridge/status`
+  - `device`: `devices` 설정 또는 브리지 기본 정보
+  - 선택: `suggested_area`, `device_class`, `unit_of_measurement`, `state_class`, `icon`
+- 팬 기본 제어/상태
+  - `command_topic`: `${MQTT_TOPIC_PREFIX}/${id}/set`
+  - `state_value_template`: `{{ value_json.state }}`
+  - `payload_on`: `ON`, `payload_off`: `OFF`
+- 속도/퍼센트 지원 시
+  - `percentage_state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
+  - `percentage_command_topic`: `${MQTT_TOPIC_PREFIX}/${id}/percentage/set`
+  - `percentage_value_template`: `{{ value_json.percentage | default(value_json.speed) }}`
+  - `speed_range_min`: `1`, `speed_range_max`: `100`
+- 프리셋 모드 지원 시
+  - `preset_modes`
+  - `preset_mode_command_topic`: `${MQTT_TOPIC_PREFIX}/${id}/preset_mode/set`
+  - `preset_mode_state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
+  - `preset_mode_value_template`: `{{ value_json.preset_mode }}`
+- 회전/방향 지원 시
+  - `oscillation_state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
+  - `oscillation_command_topic`: `${MQTT_TOPIC_PREFIX}/${id}/oscillation/set`
+  - `oscillation_value_template`: `{{ value_json.oscillating }}`
+  - `direction_state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
+  - `direction_command_topic`: `${MQTT_TOPIC_PREFIX}/${id}/direction/set`
+  - `direction_value_template`: `{{ value_json.direction }}`
+
 ## 예제: 속도 제어
 `cvnet.homenet_bridge.yaml`은 온/오프 패킷과 별도로 `command_speed`에서 목표 속도(`x`)를 삽입하고, `state_speed`로 현재 속도를 읽습니다.
 

--- a/docs/config-schema/light.md
+++ b/docs/config-schema/light.md
@@ -25,6 +25,38 @@
 
 모든 `command_*`는 [`CommandSchema`](./schemas.md#commandschema) 또는 CEL 표현식으로 작성할 수 있습니다.
 
+## MQTT 디스커버리 메시지 구성
+- 토픽: `homeassistant/light/<unique_id>/config`
+- 공통 필드
+  - `name`, `default_entity_id`, `unique_id`
+  - `state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
+  - `availability`: `${MQTT_TOPIC_PREFIX}/bridge/status`
+  - `device`: `devices` 설정 또는 브리지 기본 정보
+  - 선택: `suggested_area`, `device_class`, `unit_of_measurement`, `state_class`, `icon`
+- 조명 기본 제어/상태
+  - `command_topic`: `${MQTT_TOPIC_PREFIX}/${id}/set`
+  - `state_value_template`: `{{ value_json.state }}`
+  - `payload_on`: `ON`, `payload_off`: `OFF`
+- 밝기 지원 시
+  - `brightness_state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
+  - `brightness_command_topic`: `${MQTT_TOPIC_PREFIX}/${id}/brightness/set`
+  - `brightness_scale`: `255`
+  - `brightness_value_template`: `{{ value_json.brightness }}`
+- RGB 지원 시
+  - `rgb_state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
+  - `rgb_command_topic`: `${MQTT_TOPIC_PREFIX}/${id}/rgb/set`
+  - `rgb_value_template`: `{{ value_json.red }},{{ value_json.green }},{{ value_json.blue }}`
+- 색온도 지원 시
+  - `color_temp_state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
+  - `color_temp_command_topic`: `${MQTT_TOPIC_PREFIX}/${id}/color_temp/set`
+  - `color_temp_value_template`: `{{ value_json.color_temp }}`
+  - 선택: `min_mireds`, `max_mireds`
+- 효과 지원 시
+  - `effect_list`
+  - `effect_state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
+  - `effect_command_topic`: `${MQTT_TOPIC_PREFIX}/${id}/effect/set`
+  - `effect_value_template`: `{{ value_json.effect }}`
+
 ## 예제: 두 채널 동시 제어
 `kocom.homenet_bridge.yaml`에서는 한 패킷으로 두 채널을 제어하기 위해 CEL 표현식에서 다른 조명 상태(`states`)를 함께 실어 보냅니다.
 
@@ -96,4 +128,3 @@ light:
 2. `state_color_mode`를 지정하면 상태 패킷에 따라 현재 모드를 정확히 표기할 수 있습니다.
 3. 다채널·다기능 조명은 `effect_list`와 CEL 표현식을 조합해 필요한 패킷을 한 번에 보내도록 설계합니다.
 4. 효과 명령에서 문자열 비교 시 **`xstr`** 변수를 사용합니다.
-

--- a/docs/config-schema/lock.md
+++ b/docs/config-schema/lock.md
@@ -13,6 +13,22 @@
 ## 옵션 필드 (명령)
 - 추가 옵션 없음.
 
+## MQTT 디스커버리 메시지 구성
+- 토픽: `homeassistant/lock/<unique_id>/config`
+- 공통 필드
+  - `name`, `default_entity_id`, `unique_id`
+  - `state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
+  - `availability`: `${MQTT_TOPIC_PREFIX}/bridge/status`
+  - `device`: `devices` 설정 또는 브리지 기본 정보
+  - 선택: `suggested_area`, `device_class`, `unit_of_measurement`, `state_class`, `icon`
+- 잠금 전용
+  - `command_topic`: `${MQTT_TOPIC_PREFIX}/${id}/set`
+  - `value_template`: `{{ value_json.state }}`
+  - `state_locked`: `LOCKED`, `state_unlocked`: `UNLOCKED`
+  - `state_locking`: `LOCKING`, `state_unlocking`: `UNLOCKING`
+  - `state_jammed`: `JAMMED`
+  - `payload_lock`: `LOCK`, `payload_unlock`: `UNLOCK`
+
 ## 예제: 가스 밸브 잠금 제어
 `kocom_theart.homenet_bridge.yaml`에서는 상태 비트로 잠금/해제를 구분합니다.【F:packages/core/config/examples/kocom_theart.homenet_bridge.yaml†L496-L540】
 

--- a/docs/config-schema/number.md
+++ b/docs/config-schema/number.md
@@ -20,6 +20,20 @@
   - `multiply_factor`: 값에 곱할 배수 (기본값: 1)
   - `value_encode`: 인코딩 방식 (`none`, `bcd`, `ascii`, `signed_byte_half_degree`, 기본값: `none`)
 
+## MQTT 디스커버리 메시지 구성
+- 토픽: `homeassistant/number/<unique_id>/config`
+- 공통 필드
+  - `name`, `default_entity_id`, `unique_id`
+  - `state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
+  - `availability`: `${MQTT_TOPIC_PREFIX}/bridge/status`
+  - `device`: `devices` 설정 또는 브리지 기본 정보
+  - 선택: `suggested_area`, `device_class`, `unit_of_measurement`, `state_class`, `icon`
+- 숫자 입력 전용
+  - `command_topic`: `${MQTT_TOPIC_PREFIX}/${id}/set`
+  - `value_template`: `{{ value_json.value }}`
+  - 선택: `min`/`max`/`step` (각각 `min_value`/`max_value`/`step`에서 매핑)
+  - `mode`: `slider`
+
 ## 예제: 난방 설정값 슬라이더 (예시)
 ```yaml
 number:

--- a/docs/config-schema/select.md
+++ b/docs/config-schema/select.md
@@ -18,6 +18,19 @@
   - **스키마 기반**: `data`, `value_offset`, `map` 으로 문자열→숫자 매핑
   - **CEL 표현식**: `xstr` 변수로 선택된 옵션을 받아 바이트 배열 반환
 
+## MQTT 디스커버리 메시지 구성
+- 토픽: `homeassistant/select/<unique_id>/config`
+- 공통 필드
+  - `name`, `default_entity_id`, `unique_id`
+  - `state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
+  - `availability`: `${MQTT_TOPIC_PREFIX}/bridge/status`
+  - `device`: `devices` 설정 또는 브리지 기본 정보
+  - 선택: `suggested_area`, `device_class`, `unit_of_measurement`, `state_class`, `icon`
+- 선택형 입력 전용
+  - `command_topic`: `${MQTT_TOPIC_PREFIX}/${id}/set`
+  - `value_template`: `{{ value_json.option }}`
+  - `options`: 설정의 `options` 배열 그대로
+
 ## 예제 1: 스키마 기반 (map 사용)
 ```yaml
 select:

--- a/docs/config-schema/sensor.md
+++ b/docs/config-schema/sensor.md
@@ -10,6 +10,18 @@
   - `state_number`: [`StateNumSchema`](./schemas.md#statenumschema)로 바이트를 숫자로 변환.
   - `state_value`: CEL 표현식으로 숫자를 반환.
 
+## MQTT 디스커버리 메시지 구성
+- 토픽: `homeassistant/sensor/<unique_id>/config`
+- 공통 필드
+  - `name`, `default_entity_id`, `unique_id`
+  - `state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
+  - `availability`: `${MQTT_TOPIC_PREFIX}/bridge/status`
+  - `device`: `devices` 설정 또는 브리지 기본 정보
+  - 선택: `suggested_area`, `device_class`, `unit_of_measurement`, `state_class`, `icon`
+- 센서 전용
+  - `value_template`: `{{ value_json.value }}`
+  - 센서는 읽기 전용이라 `command_topic`이 없습니다.
+
 ## 예제 1: 스키마 기반 (StateNumSchema)
 ```yaml
 sensor:

--- a/docs/config-schema/switch.md
+++ b/docs/config-schema/switch.md
@@ -10,6 +10,19 @@ On/Off 토글 장치는 `switch` 엔티티를 사용합니다. `type`은 `switch
 ## 옵션 필드
 - 동작 모드: `optimistic` (true 설정 시 즉시 상태 반영 및 가상 스위치 지원)
 
+## MQTT 디스커버리 메시지 구성
+- 토픽: `homeassistant/switch/<unique_id>/config`
+- 공통 필드
+  - `name`, `default_entity_id`, `unique_id`
+  - `state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
+  - `availability`: `${MQTT_TOPIC_PREFIX}/bridge/status`
+  - `device`: `devices` 설정 또는 브리지 기본 정보
+  - 선택: `suggested_area`, `device_class`, `unit_of_measurement`, `state_class`, `icon`
+- 스위치 전용
+  - `command_topic`: `${MQTT_TOPIC_PREFIX}/${id}/set`
+  - `value_template`: `{{ value_json.state }}`
+  - `payload_on`: `ON`, `payload_off`: `OFF`
+
 ## 예제: 도어 호출 스위치
 `hyundai_door.homenet_bridge.yaml`은 호출 스위치에 온/오프 패킷을 배치하고 상태 비트로 켜짐 여부를 확인합니다.【F:packages/core/config/hyundai_door.homenet_bridge.yaml†L52-L69】
 

--- a/docs/config-schema/text-sensor.md
+++ b/docs/config-schema/text-sensor.md
@@ -10,6 +10,18 @@
   - **CEL (추천)**: `data[8] == 1 ? "상승" : "하강"` 과 같이 로직으로 문자열 반환.
   - **스키마**: [`StateSchema`](./schemas.md#stateschema)를 사용하여 특정 위치의 ASCII 문자를 읽음.
 
+## MQTT 디스커버리 메시지 구성
+- 토픽: `homeassistant/text_sensor/<unique_id>/config`
+- 공통 필드
+  - `name`, `default_entity_id`, `unique_id`
+  - `state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
+  - `availability`: `${MQTT_TOPIC_PREFIX}/bridge/status`
+  - `device`: `devices` 설정 또는 브리지 기본 정보
+  - 선택: `suggested_area`, `device_class`, `unit_of_measurement`, `state_class`, `icon`
+- 텍스트 센서 전용
+  - `value_template`: `{{ value_json.text }}`
+  - 텍스트 센서는 읽기 전용이라 `command_topic`이 없습니다.
+
 ## 예제 1: 스키마 기반 (ASCII 추출)
 패킷의 특정 오프셋에서 ASCII 문자열을 직접 읽어옵니다.
 ```yaml

--- a/docs/config-schema/text.md
+++ b/docs/config-schema/text.md
@@ -15,6 +15,19 @@
 - `optimistic`: `true`로 설정하면 패킷 전송 없이 상태만 관리하는 가상 텍스트로 동작.
 - `initial_value`: 초기 상태 문자열 값 (`optimistic: true`와 함께 사용).
 
+## MQTT 디스커버리 메시지 구성
+- 토픽: `homeassistant/text/<unique_id>/config`
+- 공통 필드
+  - `name`, `default_entity_id`, `unique_id`
+  - `state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
+  - `availability`: `${MQTT_TOPIC_PREFIX}/bridge/status`
+  - `device`: `devices` 설정 또는 브리지 기본 정보
+  - 선택: `suggested_area`, `device_class`, `unit_of_measurement`, `state_class`, `icon`
+- 텍스트 입력 전용
+  - `command_topic`: `${MQTT_TOPIC_PREFIX}/${id}/set`
+  - `value_template`: `{{ value_json.text }}`
+  - 선택: `min`/`max`/`pattern`/`mode` (각각 `min_length`/`max_length`/`pattern`/`mode`에서 매핑)
+
 ## 예제 1: 스키마 기반 (ASCII 전송)
 입력받은 문자열을 ASCII로 인코딩하여 패킷의 특정 위치에 삽입합니다.
 ```yaml

--- a/docs/config-schema/valve.md
+++ b/docs/config-schema/valve.md
@@ -16,6 +16,28 @@
 - 추가 제어: `command_stop`.
 - 위치 제어: `command_position` — 입력 퍼센트 값을 바이트에 삽입.
 
+## MQTT 디스커버리 메시지 구성
+- 토픽: `homeassistant/valve/<unique_id>/config`
+- 공통 필드
+  - `name`, `default_entity_id`, `unique_id`
+  - `state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
+  - `availability`: `${MQTT_TOPIC_PREFIX}/bridge/status`
+  - `device`: `devices` 설정 또는 브리지 기본 정보
+  - 선택: `suggested_area`, `device_class`, `unit_of_measurement`, `state_class`, `icon`
+- 밸브 전용
+  - `command_topic`: `${MQTT_TOPIC_PREFIX}/${id}/set`
+  - `value_template`: `{{ value_json.state }}`
+  - `state_open`: `OPEN`, `state_opening`: `OPENING`
+  - `state_closed`: `CLOSED`, `state_closing`: `CLOSING`
+  - `payload_open`: `OPEN`, `payload_close`: `CLOSE`
+  - 선택: `payload_stop` (`command_stop` 설정 시)
+- 위치 지원 시
+  - `position_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
+  - `set_position_topic`: `${MQTT_TOPIC_PREFIX}/${id}/position/set`
+  - `position_template`: `{{ value_json.position }}`
+  - `position_open`: `100`, `position_closed`: `0`
+  - 선택: `reports_position`
+
 ## 예제: 가스 밸브 닫기 명령
 `cvnet.homenet_bridge.yaml`에서는 `state_open/closed`로 상태를 구분하고, 닫기 명령을 전송합니다.【F:packages/core/config/cvnet.homenet_bridge.yaml†L110-L123】
 


### PR DESCRIPTION
### Motivation
- Home Assistant 연동을 위해 각 엔티티별로 발행되는 MQTT discovery 메시지의 토픽과 필드를 문서로 정리하려는 목적입니다.
- 브리지의 `DiscoveryManager`가 발행하는 필드(`state_topic`, `command_topic`, `availability` 등)를 사용자에게 명확히 안내하기 위함입니다.

### Description
- `docs/config-schema/`의 엔티티별 문서에 `MQTT 디스커버리 메시지 구성` 섹션을 추가했습니다 (예: `homeassistant/light/<unique_id>/config`).
- 변경된 파일: `binary-sensor.md`, `button.md`, `climate.md`, `fan.md`, `light.md`, `lock.md`, `number.md`, `select.md`, `sensor.md`, `switch.md`, `text.md`, `text-sensor.md`, `valve.md`에 토픽 및 주요 페이로드 필드(예: `state_topic`, `command_topic`, 템플릿/페이로드 매핑)를 명시했습니다.
- 문서에 사용된 변수 표기에는 브리지 환경변수/접두사 연동을 위해 `${MQTT_TOPIC_PREFIX}/${id}/...` 형태의 예시를 사용했습니다.
- 코드 변경은 없고 문서 보완만 수행했습니다; `DiscoveryManager` 구현과 일관되게 매핑되도록 기술하였습니다.

### Testing
- 문서 변경만으로 코드 빌드/린트/테스트는 생략했습니다 (`precommit` 규칙에 따라 문서 전용 변경은 테스트 생략).
- 자동화된 테스트는 실행하지 않았으며 변경 사항은 문서 추가(비파괴적)입니다.
- 관련 동작 검증은 `DiscoveryManager` 동작과 실제 MQTT 브로커 연결 환경에서 통합 테스트로 별도 확인 가능합니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e451a19e8832cb63c22b171b298d3)