### PR TITLE
유효 패킷 전용 스트리밍 및 로깅 기능 추가

### DIFF
--- a/packages/core/src/service/bridge.service.ts
+++ b/packages/core/src/service/bridge.service.ts
@@ -43,6 +43,7 @@ interface PortContext {
   automationManager: AutomationManager;
   rawPacketListener: ((data: Buffer) => void) | null;
   lastPacketTimestamp: number | null;
+  lastValidPacketTimestamp: number | null;
   packetIntervals: number[];
 }
 
@@ -86,6 +87,11 @@ export class HomeNetBridge {
 
   private normalizeCommandName(commandName: string) {
     return commandName.startsWith('command_') ? commandName : `command_${commandName}`;
+  }
+
+  private getMonotonicMs() {
+    const hrNow = process.hrtime.bigint();
+    return Number((hrNow - this.hrtimeBase) / 1000000n);
   }
 
   async start() {
@@ -687,8 +693,26 @@ export class HomeNetBridge {
         automationManager,
         rawPacketListener: null,
         lastPacketTimestamp: null,
+        lastValidPacketTimestamp: null,
         packetIntervals: [],
       };
+
+      packetProcessor.on('packet', (packet) => {
+        if (!context.rawPacketListener) return;
+
+        const now = this.getMonotonicMs();
+        const interval =
+          context.lastValidPacketTimestamp !== null ? now - context.lastValidPacketTimestamp : null;
+        context.lastValidPacketTimestamp = now;
+
+        const hexPacket = packet.map((b: number) => b.toString(16).padStart(2, '0')).join('');
+        eventBus.emit('raw-valid-packet', {
+          portId: normalizedPortId,
+          payload: hexPacket,
+          interval,
+          receivedAt: new Date().toISOString(),
+        });
+      });
 
       port.on('data', (data) => {
         if (!context.rawPacketListener) {
@@ -718,9 +742,9 @@ export class HomeNetBridge {
 
     logger.info({ portId: context.portId }, '[core] Starting raw packet listener.');
 
+    context.lastValidPacketTimestamp = null;
     context.rawPacketListener = (data: Buffer) => {
-      const hrNow = process.hrtime.bigint();
-      const now = Number((hrNow - this.hrtimeBase) / 1000000n); // Convert to ms
+      const now = this.getMonotonicMs();
 
       let interval: number | null = null;
 
@@ -766,6 +790,7 @@ export class HomeNetBridge {
       context.rawPacketListener = null;
       // Do not clear packetIntervals so we can recall stats in log metadata even if stream paused
       context.lastPacketTimestamp = null;
+      context.lastValidPacketTimestamp = null;
     }
   }
 

--- a/packages/ui/src/App.svelte
+++ b/packages/ui/src/App.svelte
@@ -76,6 +76,7 @@
   let packetStatsByPort = $state(new Map<string, PacketStats>());
   let hasIntervalPackets = $state(false);
   let lastRawPacketTimestamp = $state<number | null>(null);
+  let validRawPacketsOnly = $state(false);
   let toasts = $state<ToastMessage[]>([]);
   const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
   const MAX_TOASTS = 4;
@@ -101,6 +102,11 @@
   let isRecording = $state(false);
   let recordingStartTime = $state<number | null>(null);
   let recordedFile = $state<{ filename: string; path: string } | null>(null);
+  type RawPacketStreamMode = 'all' | 'valid';
+  const rawPacketStreamMode = $derived.by<RawPacketStreamMode>(() =>
+    validRawPacketsOnly ? 'valid' : 'all',
+  );
+  let lastAppliedRawPacketMode = $state<RawPacketStreamMode>('all');
 
   type StreamEvent =
     | 'status'
@@ -280,7 +286,8 @@
     if (activeView === 'analysis' || isRecording) {
       // 스트리밍 시작 & 데이터 초기화 (처음 들어올 때만)
       if (!isStreaming) {
-        sendStreamCommand('start');
+        sendStreamCommand('start', rawPacketStreamMode);
+        lastAppliedRawPacketMode = rawPacketStreamMode;
         isStreaming = true;
       }
       if (activeView === 'analysis' && rawPackets.length === 0 && !isRecording) {
@@ -294,6 +301,17 @@
         isStreaming = false;
       }
     }
+  });
+
+  $effect(() => {
+    if (!isStreaming || connectionStatus !== 'connected') return;
+    if (rawPacketStreamMode === lastAppliedRawPacketMode) return;
+    lastAppliedRawPacketMode = rawPacketStreamMode;
+    rawPackets = [];
+    packetStatsByPort = new Map();
+    hasIntervalPackets = false;
+    lastRawPacketTimestamp = null;
+    sendStreamCommand('start', rawPacketStreamMode);
   });
 
   // API 요청 helper 함수
@@ -489,12 +507,6 @@
 
     socket = new WebSocket(url.toString());
 
-    const sendStreamCommand = (command: 'start' | 'stop') => {
-      if (socket?.readyState === WebSocket.OPEN) {
-        socket.send(JSON.stringify({ command }));
-      }
-    };
-
     const handleStatus = (data: Record<string, unknown>) => {
       const state = data.state;
       if (state === 'connected') {
@@ -660,9 +672,13 @@
     socket.addEventListener('error', handleDisconnect);
   }
 
-  function sendStreamCommand(command: 'start' | 'stop') {
+  function sendStreamCommand(command: 'start' | 'stop', mode?: RawPacketStreamMode) {
     if (socket?.readyState === WebSocket.OPEN) {
-      socket.send(JSON.stringify({ command }));
+      const payload: { command: 'start' | 'stop'; mode?: RawPacketStreamMode } = { command };
+      if (command === 'start') {
+        payload.mode = mode ?? rawPacketStreamMode;
+      }
+      socket.send(JSON.stringify(payload));
     }
   }
 
@@ -1119,6 +1135,7 @@
             selectedPortId={activePortId}
             onPortChange={(portId) => (selectedPortId = portId)}
             onStart={handleRawRecordingStart}
+            bind:validOnly={validRawPacketsOnly}
             bind:isRecording
             bind:recordingStartTime
             bind:recordedFile

--- a/packages/ui/src/lib/components/RawPacketLog.svelte
+++ b/packages/ui/src/lib/components/RawPacketLog.svelte
@@ -12,6 +12,7 @@
     stats = null,
     onStart,
     onStop,
+    validOnly = $bindable(false),
     isRecording = $bindable(false),
     recordingStartTime = $bindable(null),
     recordedFile = $bindable(null),
@@ -21,6 +22,7 @@
     stats?: PacketStatsType | null;
     onStart?: () => void;
     onStop?: () => void;
+    validOnly: boolean;
     isRecording: boolean;
     recordingStartTime: number | null;
     recordedFile: { filename: string; path: string } | null;
@@ -235,7 +237,10 @@
         const response = await fetch('./api/logs/packet/start', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ uiStats: statsPayload }),
+          body: JSON.stringify({
+            uiStats: statsPayload,
+            mode: validOnly ? 'valid' : 'all',
+          }),
         });
         if (response.ok) {
           isRecording = true;
@@ -415,6 +420,10 @@
         bind:value={filterText}
       />
     </label>
+    <label class="filter-toggle">
+      <input type="checkbox" bind:checked={validOnly} />
+      <span>{$t('analysis.raw_log.valid_only_label')}</span>
+    </label>
     {#if isFiltering}
       <Button variant="secondary" onclick={() => (filterText = '')}>
         {$t('analysis.raw_log.clear_filter')}
@@ -423,6 +432,9 @@
   </div>
   {#if isFiltering}
     <p class="filter-hint">{$t('analysis.raw_log.filter_hint')}</p>
+  {/if}
+  {#if validOnly}
+    <p class="filter-hint">{$t('analysis.raw_log.valid_only_hint')}</p>
   {/if}
 
   {#if showSaveDialog && recordedFile}
@@ -582,6 +594,22 @@
     outline: none;
     border-color: rgba(59, 130, 246, 0.6);
     box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.35);
+  }
+
+  .filter-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    color: #cbd5e1;
+    font-size: 0.85rem;
+    padding: 0.2rem 0.4rem;
+    border-radius: 8px;
+    background: rgba(15, 23, 42, 0.4);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+  }
+
+  .filter-toggle input {
+    accent-color: #38bdf8;
   }
 
   .filter-hint {

--- a/packages/ui/src/lib/i18n/locales/en.json
+++ b/packages/ui/src/lib/i18n/locales/en.json
@@ -98,6 +98,8 @@
       "filter_placeholder": "Search payload, direction (RX/TX)",
       "clear_filter": "Clear Filter",
       "filter_hint": "Support wildcards (*, ?). Only the most recent 1000 packets are searched. Intervals are hidden while filtering.",
+      "valid_only_label": "Show valid packets only",
+      "valid_only_hint": "Shows packets with valid header, checksum, and footer.",
       "empty": "No packets to display.",
       "collected_packets": "Collected Packets: {count}",
       "recording_duration": "Recording Duration: {duration}",

--- a/packages/ui/src/lib/i18n/locales/ko.json
+++ b/packages/ui/src/lib/i18n/locales/ko.json
@@ -98,6 +98,8 @@
       "filter_placeholder": "payload, 방향(RX/TX) 검색",
       "clear_filter": "필터 해제",
       "filter_hint": "와일드카드(*, ?) 사용 가능. 최근 1000개 패킷만 검색됩니다. 필터링 중 간격은 숨겨집니다.",
+      "valid_only_label": "유효 패킷만 보기",
+      "valid_only_hint": "헤더, 체크섬, 푸터가 유효한 패킷만 표시합니다.",
       "empty": "표시할 패킷이 없습니다.",
       "collected_packets": "수집된 패킷: {count}",
       "recording_duration": "녹화 시간: {duration}",

--- a/packages/ui/src/lib/views/Analysis.svelte
+++ b/packages/ui/src/lib/views/Analysis.svelte
@@ -22,6 +22,7 @@
     onPortChange,
     onStart,
     onStop,
+    validOnly = $bindable(false),
     isRecording = $bindable(),
     recordingStartTime = $bindable(),
     recordedFile = $bindable(),
@@ -36,6 +37,7 @@
     onPortChange?: (portId: string) => void;
     onStart?: () => void;
     onStop?: () => void;
+    validOnly: boolean;
     isRecording: boolean;
     recordingStartTime: number | null;
     recordedFile: { filename: string; path: string } | null;
@@ -72,6 +74,7 @@
     {stats}
     {onStart}
     {onStop}
+    bind:validOnly
     bind:isRecording
     bind:recordingStartTime
     bind:recordedFile


### PR DESCRIPTION
### Motivation
- 분석 화면에서 유효한 패킷(헤더·체크섬·푸터가 유효한 것)만 보고 녹화할 수 있도록 원함.
- UI에서 토글로 전환하면 서버는 필요한 데이터만 수집해 전송하여 자원 사용을 절약해야 함.
- 기존의 원시(raw) 패킷 스트리밍/로깅 동작을 유지하면서 모드를 추가해 호환성을 보장해야 함.

### Description
- 코어에서 `PacketProcessor`의 `packet` 이벤트를 활용해 유효 패킷 전용 이벤트 `raw-valid-packet`을 추가하고 시간 계산용 `getMonotonicMs()`와 `lastValidPacketTimestamp`를 도입해 간격을 계산하도록 구현함.
- 서비스(WebSocket) 쪽에 구독자별 스트림 모드(`all` | `valid`)를 저장하도록 변경하고, `raw-valid-packet`을 모드별로만 전송하도록 `sendToRawSubscribers`를 확장함.
- 로거(`RawPacketLoggerService`)에 `mode` 옵션을 추가해 `start(meta, { mode })`로 유효패킷 전용(`valid`) 또는 전체(`all`) 기록을 선택 가능하게 하고, 메타 헤더에 모드 정보를 기록하도록 수정함.
- UI에 `유효 패킷만 보기` 체크박스를 추가하고 `App.svelte`→`Analysis.svelte`→`RawPacketLog.svelte`로 바인딩하여 스트리밍 시작/녹화 시 선택한 모드를 서버에 전달하도록 변경했으며 i18n 문구도 갱신함.

### Testing
- 빌드: `pnpm build` 를 실행했으며 UI 빌드 포함 전체 빌드가 성공했습니다.
- 린트: `pnpm lint` 를 실행했으며 `tsc` / `svelte-check` 기준으로 문제 없이 성공했습니다.
- 테스트: `pnpm test` 로 Vitest 전체 스위트를 실행했으며 자동화 테스트가 통과하여 모든 테스트가 성공(`227 tests passed`)했습니다.
- 시각 검증: 로컬 개발 서버를 띄워 UI에서 Analysis 화면의 토글이 표시되는 스크린샷을 생성했습니다 (`artifacts/raw-packet-valid-only.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f82acb780832c8ac50cf5a07a6efa)