### PR TITLE
text_sensor 디스커버리를 Home Assistant `sensor` 도메인으로 발행

### DIFF
--- a/docs/config-schema/text-sensor.md
+++ b/docs/config-schema/text-sensor.md
@@ -11,7 +11,7 @@
   - **스키마**: [`StateSchema`](./schemas.md#stateschema)를 사용하여 특정 위치의 ASCII 문자를 읽음.
 
 ## MQTT 디스커버리 메시지 구성
-- 토픽: `homeassistant/text_sensor/<unique_id>/config`
+- 토픽: `homeassistant/sensor/<unique_id>/config` (Home Assistant가 `text_sensor` 도메인을 인식하지 않으므로 `sensor`로 발행)
 - 공통 필드
   - `name`, `default_entity_id`, `unique_id`
   - `state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`

--- a/packages/core/src/mqtt/discovery-manager.ts
+++ b/packages/core/src/mqtt/discovery-manager.ts
@@ -72,7 +72,8 @@ export class DiscoveryManager {
     }
 
     const uniqueId = this.ensureUniqueId(entity);
-    const topic = `${this.discoveryPrefix}/${entity.type}/${uniqueId}/config`;
+    const discoveryType = this.resolveDiscoveryType(entity.type);
+    const topic = `${this.discoveryPrefix}/${discoveryType}/${uniqueId}/config`;
 
     this.publisher.publish(topic, '', { retain: true });
 
@@ -197,7 +198,8 @@ export class DiscoveryManager {
     }
 
     const uniqueId = this.ensureUniqueId(entity);
-    const topic = `${this.discoveryPrefix}/${entity.type}/${uniqueId}/config`;
+    const discoveryType = this.resolveDiscoveryType(entity.type);
+    const topic = `${this.discoveryPrefix}/${discoveryType}/${uniqueId}/config`;
 
     this.publisher.publish(topic, '', { retain: true });
     logger.debug({ topic }, '[DiscoveryManager] Cleared retained discovery for renamed entity');
@@ -214,6 +216,13 @@ export class DiscoveryManager {
       entity.unique_id = `homenet_${this.portId}_${entity.id}`;
     }
     return entity.unique_id;
+  }
+
+  private resolveDiscoveryType(type: string): string {
+    if (type === 'text_sensor') {
+      return 'sensor';
+    }
+    return type;
   }
 
   private buildObjectId(entity: EntityConfig): string {
@@ -298,14 +307,15 @@ export class DiscoveryManager {
 
     const uniqueId = this.ensureUniqueId(entity);
     const objectId = this.buildObjectId(entity);
-    const topic = `${this.discoveryPrefix}/${type}/${uniqueId}/config`;
+    const discoveryType = this.resolveDiscoveryType(type);
+    const topic = `${this.discoveryPrefix}/${discoveryType}/${uniqueId}/config`;
 
     logger.debug({ id, uniqueId, topic }, '[DiscoveryManager] Preparing discovery');
 
     // Base payload with mandatory fields only
     const payload: DiscoveryPayload = {
       name: name || null,
-      default_entity_id: `${type}.${objectId}`,
+      default_entity_id: `${discoveryType}.${objectId}`,
       unique_id: uniqueId,
       state_topic: `${this.mqttTopicPrefix}/${id}/state`,
       availability: [{ topic: this.bridgeStatusTopic }],


### PR DESCRIPTION
### Motivation
- Home Assistant가 `text_sensor` 디스커버리 도메인을 인식하지 않아 디스커버리 메시지를 `sensor` 도메인으로 발행해야 합니다.
- 기존 구현은 `text_sensor` 타입을 그대로 `homeassistant/text_sensor/...` 토픽으로 발행하고 있었습니다.

### Description
- `DiscoveryManager`에 `resolveDiscoveryType` 를 추가해 `text_sensor` 타입을 `sensor` 도메인으로 매핑하도록 처리했습니다.
- `revokeDiscovery`, `handleEntityRenamed`, `publishDiscovery` 등 디스커버리 토픽 생성부에서 매핑된 도메인(`discoveryType`)을 사용하도록 변경했습니다.
- 디스커버리 페이로드의 `default_entity_id`도 매핑된 도메인으로 생성되도록 수정했습니다.
- 문서 `docs/config-schema/text-sensor.md`를 업데이트해 실제로 `homeassistant/sensor/<unique_id>/config`로 발행함을 명시했습니다.

### Testing
- 변경 후 `pnpm build`를 실행했으며 빌드가 성공했습니다.
- 변경 후 `pnpm lint`를 실행했으며 린트(`tsc`/`svelte-check`)가 성공했습니다.
- 변경 후 `pnpm test`로 Vitest 전체 테스트를 실행했고 자동화 테스트가 모두 성공했으며 `227`개의 테스트가 통과했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ff3d7bbb8832ca556cc76bcc4b5c7)