### PR TITLE
루트 `pnpm build`에서 `simulator` 패키지 제외

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Always respond with 한국어
 Monorepo lives under `packages/` with four workspaces: `core` (RS485⇢MQTT bridge logic), `service` (Express API and UI proxy), `simulator` (virtual RS485 PTY), and `ui` (Svelte SPA). Shared configs (`tsconfig.base.json`, `vitest.config.ts`, `pnpm-workspace.yaml`) sit at the root, while Docker assets live in `deploy/docker/`. Source and colocated tests stay inside each package (`src/`, `test/`, or `src/__tests__/`). Keep env artifacts like `.env` or `options.json` out of version control.
 
 ## Build, Test, and Development Commands
-Use `pnpm` from the repo root. `pnpm core:dev`, `pnpm service:dev`, and `pnpm ui:dev` start package-specific watch modes. `pnpm build` compiles all workspaces (TypeScript → `dist/`, Vite bundle for UI). `pnpm lint` runs `tsc --noEmit` plus `svelte-check`. Run `pnpm test` for the Vitest suite or filter packages via `pnpm --filter @rs485-homenet/core test`.
+Use `pnpm` from the repo root. `pnpm core:dev`, `pnpm service:dev`, and `pnpm ui:dev` start package-specific watch modes. `pnpm build` compiles all workspaces except `simulator` (TypeScript → `dist/`, Vite bundle for UI). `pnpm lint` runs `tsc --noEmit` plus `svelte-check`. Run `pnpm test` for the Vitest suite or filter packages via `pnpm --filter @rs485-homenet/core test`.
 
 ## Coding Style & Naming Conventions
 Code uses ES modules, TypeScript, and 2-space indentation. Prefer `const`, arrow callbacks, and single quotes; mirror the style in `packages/core/src/index.ts`. Name files after their primary export (`homeNetBridge.test.ts`, `server.ts`), Svelte components use PascalCase `.svelte`, helpers use camelCase. Export factories/classes instead of singletons to simplify testing. Keep configuration in code via typed options, never hardcode MQTT topics or credentials.
@@ -41,7 +41,7 @@ This document guides you through setting up and running the full "Homenet2MQTT" 
     -   Run `pnpm install` in the project root directory.
 
 3.  **Build the Project**:
-    -   Run `pnpm build` to build all packages. The `service` package builds the `ui` package and copies its output to its own `static` directory.
+    -   Run `pnpm build` to build all packages except `simulator`. The `service` package builds the `ui` package and copies its output to its own `static` directory.
 
 4.  **Create a Test Configuration File**:
     -   In the `packages/core/config/` directory, create a test configuration file, such as `test.homenet_bridge.yaml`.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dev:frontend": "pnpm --filter @rs485-homenet/ui dev",
     "simulate": "node packages/simulator/scripts/convert_trace.js",
     "lint": "pnpm -r lint",
-    "build": "pnpm -r build",
+    "build": "pnpm -r --filter '!@rs485-homenet/simulator' build",
     "format": "pnpm -r --if-present format",
     "test": "vitest run",
     "clean": "sudo bash ./scripts/clean.sh",


### PR DESCRIPTION
### Motivation
- `pnpm build` 실행 시 `simulator` 패키지를 빌드 대상에서 제외하도록 해 전체 빌드 시간을 단축하고 불필요한 빌드 실패를 방지하기 위함입니다.
- `simulator`는 시뮬레이션 전용으로 로컬/개발 환경에서만 필요하므로 루트 전역 빌드에서 제외하는 것이 적절합니다.

### Description
- 루트 `package.json`의 `build` 스크립트를 `pnpm -r --filter '!@rs485-homenet/simulator' build`로 변경했습니다.
- 문서 `AGENTS.md`의 빌드 안내 문구를 수정해 `pnpm build`가 `simulator`를 제외한다고 명시했습니다.

### Testing
- 실행한 명령: `pnpm build`, 결과: 빌드가 성공하여 루트 워크스페이스(단, `simulator` 제외) 출력이 생성되었습니다.
- 실행한 명령: `pnpm lint`, 결과: 실패했고 원인은 `packages/simulator/src/index.ts`에서 `./packets_from_userdata` 모듈을 찾지 못한 에러입니다.
- 실행한 명령: `pnpm test`, 결과: 테스트 스위트가 성공적으로 통과했습니다 (모든 자동화 테스트 통과).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953918bfdc4832c9d1c001d83552794)