### PR TITLE
기본 CONFIG_FILES 주입에 쉼표 추가하여 경고 제거

### DIFF
--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -14,7 +14,7 @@ services:
     image: nubiz/homenet2mqtt:latest
     container_name: homenet2mqtt
     environment:
-      CONFIG_FILES: default.homenet_bridge.yaml
+      CONFIG_FILES: default.homenet_bridge.yaml,
       MQTT_URL: mqtt://localhost:1883
       PORT: '3000'
       LOG_LEVEL: info
@@ -43,7 +43,7 @@ services:
 
 | 변수 | 기본값 | 설명 |
 | --- | --- | --- |
-| `CONFIG_FILES` | `default.homenet_bridge.yaml` | 설정 파일 목록 (쉼표로 구분) |
+| `CONFIG_FILES` | `default.homenet_bridge.yaml,` | 설정 파일 목록 (쉼표로 구분) |
 | `CONFIG_ROOT` | `/config` | 설정 파일 경로 |
 | `MQTT_URL` | `mqtt://localhost:1883` | MQTT 브로커 URL |
 | `MQTT_NEED_LOGIN` | `false` | MQTT 인증 사용 여부 |

--- a/hassio-addon-dev/run.sh
+++ b/hassio-addon-dev/run.sh
@@ -22,7 +22,7 @@ if [ -f "$CONFIG_PATH" ]; then
   fi
   
   if [ -z "$CONFIG_FILES" ] || [ "$CONFIG_FILES" == "null" ]; then
-    CONFIG_FILES="default.homenet_bridge.yaml"
+    CONFIG_FILES="default.homenet_bridge.yaml,"
   fi
   
   export CONFIG_FILES="$CONFIG_FILES"
@@ -38,7 +38,7 @@ else
   export MQTT_USER="${MQTT_USER:-}"
   export MQTT_PASSWD="${MQTT_PASSWD:-}"
   export MQTT_TOPIC_PREFIX="${MQTT_TOPIC_PREFIX:-homenet2mqtt}"
-  export CONFIG_FILES="${CONFIG_FILES:-default.homenet_bridge.yaml}"
+  export CONFIG_FILES="${CONFIG_FILES:-default.homenet_bridge.yaml,}"
   
   # CONFIG_ROOT 환경변수 또는 기본값 /config 사용
   HA_CONFIG_DIR="${CONFIG_ROOT:-/config}"

--- a/hassio-addon/run.sh
+++ b/hassio-addon/run.sh
@@ -22,7 +22,7 @@ if [ -f "$CONFIG_PATH" ]; then
   fi
   
   if [ -z "$CONFIG_FILES" ] || [ "$CONFIG_FILES" == "null" ]; then
-    CONFIG_FILES="default.homenet_bridge.yaml"
+    CONFIG_FILES="default.homenet_bridge.yaml,"
   fi
   
   export CONFIG_FILES="$CONFIG_FILES"
@@ -38,7 +38,7 @@ else
   export MQTT_USER="${MQTT_USER:-}"
   export MQTT_PASSWD="${MQTT_PASSWD:-}"
   export MQTT_TOPIC_PREFIX="${MQTT_TOPIC_PREFIX:-homenet2mqtt}"
-  export CONFIG_FILES="${CONFIG_FILES:-default.homenet_bridge.yaml}"
+  export CONFIG_FILES="${CONFIG_FILES:-default.homenet_bridge.yaml,}"
   
   # CONFIG_ROOT 환경변수 또는 기본값 /config 사용
   HA_CONFIG_DIR="${CONFIG_ROOT:-/config}"


### PR DESCRIPTION
### Motivation

- `CONFIG_FILES`가 비어있을 때 서버의 `parseEnvList`에서 "단일 값" 경고가 발생하는 문제를 방지하기 위해 기본값에 쉼표를 포함하도록 변경했습니다.
- 애드온 실행 스크립트와 Docker 문서의 기본값 표기를 일관화하여 사용자 혼선을 줄이기 위함입니다.

### Description

- `hassio-addon/run.sh`와 `hassio-addon-dev/run.sh`에서 기본값을 `default.homenet_bridge.yaml`에서 `default.homenet_bridge.yaml,`로 변경하여 쉼표 포함 문자열을 주입하도록 수정했습니다.
- `deploy/docker/README.md`의 `CONFIG_FILES` 기본값 표기를 `default.homenet_bridge.yaml,`로 업데이트하여 문서와 스크립트를 동기화했습니다.
- 변경으로 인해 애드온/컨테이너가 초기화 시 기본 설정을 주입할 때 `[service] CONFIG_FILES에 단일 값...` 경고가 발생하지 않습니다.

### Testing

- `pnpm build`를 실행했고 빌드가 성공했습니다.
- `pnpm lint`를 실행했고 `tsc` 및 `svelte-check` 린트가 통과했습니다.
- `pnpm test`를 실행했고 Vitest 테스트 스위트가 모두 통과했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953d97fab18832c941510198a9fdb3a)