### PR TITLE
Commax 엘리베이터 스니펫 BCD 디코드 및 버전 패치

### DIFF
--- a/gallery/commax/elevator.yaml
+++ b/gallery/commax/elevator.yaml
@@ -3,7 +3,7 @@ meta:
   name_en: "Elevator Call"
   description: "코맥스 엘리베이터 호출 버튼과 현재 층수 센서 설정입니다."
   description_en: "Commax elevator call button and current floor sensor."
-  version: "1.0.0"
+  version: "1.0.1"
   author: "wooooooooooook"
   tags: ["elevator", "button", "sensor", "commax"]
 

--- a/gallery/commax/elevator_26.yaml
+++ b/gallery/commax/elevator_26.yaml
@@ -3,7 +3,7 @@ meta:
   name_en: "Elevator Call"
   description: "코맥스 엘리베이터 호출 버튼과 26으로 시작하는 층수 센서 설정입니다."
   description_en: "Commax elevator call button and current floor sensor."
-  version: "1.0.0"
+  version: "1.0.1"
   author: "wooooooooooook"
   tags: ["elevator", "button", "sensor", "commax"]
 
@@ -21,6 +21,7 @@ entities:
         offset: 5
         length: 1
         precision: 0
+        decode: bcd
 
   #명령 0xA0, 0x01, 0x01, 0x00, 0x08, 0x15, 0x00, add checksum
   button:

--- a/gallery/list.json
+++ b/gallery/list.json
@@ -28,7 +28,7 @@
           "name_en": "Elevator Call",
           "description": "코맥스 엘리베이터 호출 버튼과 현재 층수 센서 설정입니다.",
           "description_en": "Commax elevator call button and current floor sensor.",
-          "version": "1.0.0",
+          "version": "1.0.1",
           "author": "wooooooooooook",
           "tags": [
             "elevator",
@@ -51,7 +51,7 @@
           "name_en": "Elevator Call",
           "description": "코맥스 엘리베이터 호출 버튼과 26으로 시작하는 층수 센서 설정입니다.",
           "description_en": "Commax elevator call button and current floor sensor.",
-          "version": "1.0.0",
+          "version": "1.0.1",
           "author": "wooooooooooook",
           "tags": [
             "elevator",


### PR DESCRIPTION
### Motivation
- 코맥스 엘리베이터 스니펫에서 층수 센서가 BCD로 전송되는 경우를 명시적으로 처리하기 위해 디코드 옵션을 추가했습니다.
- 스니펫 변경을 명확히 하기 위해 메타 버전을 패치 수준으로 올려 갤러리와 동기화했습니다.

### Description
- `gallery/commax/elevator_26.yaml`의 `state_number`에 `decode: bcd` 옵션을 추가했습니다.
- `gallery/commax/elevator.yaml`과 `gallery/commax/elevator_26.yaml`의 `meta.version`을 `1.0.0`에서 `1.0.1`로 상향했습니다.
- `gallery/list.json`의 해당 항목들 버전 정보를 `1.0.1`로 동기화했습니다.

### Testing
- `pnpm build`를 실행하여 전체 빌드가 성공했음을 확인했습니다 (UI 정적 파일 동기화 포함).
- `pnpm lint`를 실행하여 타입 및 Svelte 검사가 문제 없음을 확인했습니다.
- `pnpm test`로 Vitest 전체 테스트 스위트를 실행했으며 모든 테스트가 통과했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953e2d2b5b8832ca42740e9429bbb71)