### PR TITLE
툴바/하위 컴포넌트 each 블록에 안정적인 키 추가

### DIFF
--- a/packages/ui/src/lib/components/GalleryItemCard.svelte
+++ b/packages/ui/src/lib/components/GalleryItemCard.svelte
@@ -72,7 +72,7 @@
       <div class="summary-section">
         <span class="summary-label">{$t('gallery.entities')}:</span>
         <div class="summary-items">
-          {#each entityTypes as [type, count]}
+          {#each entityTypes as [type, count], index (`${type}-${index}`)}
             <span class="badge entity">{type}: {count}</span>
           {/each}
         </div>
@@ -94,7 +94,7 @@
 
   {#if item.tags.length > 0}
     <div class="tags">
-      {#each item.tags as tag}
+      {#each item.tags as tag, index (`${tag}-${index}`)}
         <span class="tag">{tag}</span>
       {/each}
     </div>

--- a/packages/ui/src/lib/components/GalleryPreviewModal.svelte
+++ b/packages/ui/src/lib/components/GalleryPreviewModal.svelte
@@ -325,7 +325,7 @@
           <div class="contents-summary">
             <h4>{$t('gallery.preview.contents')}</h4>
             <div class="summary-badges">
-              {#each Object.entries(item.content_summary.entities) as [type, count]}
+              {#each Object.entries(item.content_summary.entities) as [type, count], index (`${type}-${index}`)}
                 <span class="badge entity"
                   >{$t('gallery.preview.entity_count', {
                     values: { type, count },
@@ -351,7 +351,7 @@
             <div class="tags-section">
               <span class="info-label">{$t('gallery.tags')}</span>
               <div class="tags">
-                {#each item.tags as tag}
+                {#each item.tags as tag, index (`${tag}-${index}`)}
                   <span class="tag">{tag}</span>
                 {/each}
               </div>
@@ -382,7 +382,7 @@
           <div class="port-select">
             <label for="port-select">{$t('gallery.preview.select_port')}</label>
             <select id="port-select" bind:value={selectedPortId}>
-              {#each ports as port}
+              {#each ports as port, index (`${port.portId}-${index}`)}
                 <option value={port.portId}>{port.portId} ({port.path})</option>
               {/each}
             </select>
@@ -421,7 +421,7 @@
           <h4>⚠️ {$t('gallery.preview.compatibility.incompatible')}</h4>
           <p class="mismatch-label">{$t('gallery.preview.compatibility.mismatch_label')}:</p>
           <ul class="mismatch-list">
-            {#each compatibility.mismatches as mismatch}
+            {#each compatibility.mismatches as mismatch, index (`${mismatch.field}-${index}`)}
               <li>
                 <code>{mismatch.field}</code>:
                 <span class="expected"
@@ -456,7 +456,7 @@
         </p>
 
         <div class="conflict-list">
-          {#each conflicts as conflict}
+          {#each conflicts as conflict, index (`${conflict.id}-${index}`)}
             <div class="conflict-item">
               <div class="conflict-header">
                 <span class="conflict-id">
@@ -530,7 +530,7 @@
         <div class="new-items-section">
           <h4>{$t('gallery.preview.new_items', { values: { count: newItems.length } })}</h4>
           <ul class="new-items-list">
-            {#each newItems as newItem}
+            {#each newItems as newItem, index (`${newItem.id}-${index}`)}
               <li>
                 • {newItem.id} ({newItem.type})
               </li>

--- a/packages/ui/src/lib/components/RawPacketLog.svelte
+++ b/packages/ui/src/lib/components/RawPacketLog.svelte
@@ -364,7 +364,7 @@
   <div class="log-item" class:tx-packet={packet.direction === 'TX'}>
     <span class="time">[{new Date(packet.receivedAt).toLocaleTimeString()}]</span>
     <span class="direction" class:tx={packet.direction === 'TX'}>
-      {#each getHighlightedParts(packet.direction ?? 'RX', normalizedFilter) as part}
+      {#each getHighlightedParts(packet.direction ?? 'RX', normalizedFilter) as part, index (`${part}-${index}`)}
         {#if part.highlight}
           <mark>{part.text}</mark>
         {:else}
@@ -380,7 +380,7 @@
       >
     {/if}
     <code class="payload" class:tx-payload={packet.direction === 'TX'}>
-      {#each getHighlightedParts(toHexPairs(packet.payload).join(' '), normalizedFilter) as part}
+      {#each getHighlightedParts(toHexPairs(packet.payload).join(' '), normalizedFilter) as part, index (`${part}-${index}`)}
         {#if part.highlight}
           <mark>{part.text}</mark>
         {:else}

--- a/packages/ui/src/lib/components/SetupWizard.svelte
+++ b/packages/ui/src/lib/components/SetupWizard.svelte
@@ -591,7 +591,7 @@
           <label for="example-select">{$t('setup_wizard.example_label')}</label>
           <select id="example-select" bind:value={selectedExample} disabled={submitting}>
             <option value={EMPTY_CONFIG_VALUE}>{$t('setup_wizard.empty_option')}</option>
-            {#each examples as example}
+            {#each examples as example (example)}
               <option value={example}>{getExampleDisplayName(example)}</option>
             {/each}
           </select>
@@ -712,7 +712,7 @@
                 <div class="result-list">
                   <div class="result-row">
                     <code>
-                      {#each testPackets as packet, index}
+                      {#each testPackets as packet, index (`${packet}-${index}`)}
                         {packet}
                       {/each}
                     </code>
@@ -886,7 +886,7 @@
           </div>
         {:else}
           <div class="entity-list-container">
-            {#each Object.entries(entities) as [type, items]}
+            {#each Object.entries(entities) as [type, items] (type)}
               <div class="entity-group">
                 <div class="entity-type-header">
                   <label class="checkbox-label">
@@ -903,7 +903,7 @@
                   </label>
                 </div>
                 <div class="entity-items">
-                  {#each items as item}
+                  {#each items as item (item.id)}
                     <label class="checkbox-label entity-item">
                       <input
                         type="checkbox"

--- a/packages/ui/src/lib/views/Gallery.svelte
+++ b/packages/ui/src/lib/views/Gallery.svelte
@@ -175,7 +175,7 @@
         <label for="vendor-select">{$t('gallery.vendor')}</label>
         <select id="vendor-select" bind:value={selectedVendor}>
           <option value={null}>{$t('gallery.filter_all')}</option>
-          {#each galleryData.vendors as vendor}
+          {#each galleryData.vendors as vendor (vendor.id)}
             <option value={vendor.id}>{vendor.name}</option>
           {/each}
         </select>

--- a/packages/ui/src/lib/views/Settings.svelte
+++ b/packages/ui/src/lib/views/Settings.svelte
@@ -362,7 +362,7 @@
         disabled={isSaving || isLoading}
         aria-label={$t('common.language')}
       >
-        {#each $locales as l}
+        {#each $locales as l (l)}
           <option value={l}>
             {l === 'ko' ? $t('common.korean') : $t('common.english')}
           </option>
@@ -568,7 +568,7 @@
         <div class="setting files-section">
           <div class="setting-title">{$t('settings.log_retention.saved_files')}</div>
           <div class="files-list">
-            {#each cacheFiles as file}
+            {#each cacheFiles as file (file.filename)}
               <div class="file-row">
                 <span class="file-name">{file.filename}</span>
                 <span class="file-size">{formatBytes(file.size)}</span>
@@ -639,7 +639,7 @@
               <div class="bridge-info">
                 <span class="file-name">{bridge.configFile}</span>
                 <div class="bridge-details">
-                  {#each bridge.serials as serial}
+                  {#each bridge.serials as serial, index (`${serial.portId}-${index}`)}
                     <span class="badge sm">{serial.portId}: {serial.path}</span>
                   {/each}
                 </div>


### PR DESCRIPTION
### Motivation
- Svelte의 `each` 블록에서 항목이 중복될 경우 DOM 재사용으로 인해 잘못된 렌더링/갱신이 발생할 수 있어 안정적인 키가 필요했습니다.
- 툴바를 포함한 하위 컴포넌트 리스트에 고유한 키를 부여해 UI 렌더링 안정성을 개선하는 것이 목적입니다.

### Description
- 각 반복 렌더링(`{#each ...}`)에 식별자 기반의 키를 추가하여 중복 항목에도 안정적인 재사용이 되도록 했습니다 (`Gallery.svelte`, `Settings.svelte`, `SetupWizard.svelte`, `RawPacketLog.svelte`).
- 이전에 수정된 `GalleryItemCard.svelte`와 `GalleryPreviewModal.svelte`의 각 목록에도 일관된 키 패턴(예: ```${type}-${index}```, ```${tag}-${index}```, ```${port.portId}-${index}```)이 적용되어 있습니다.
- 변경은 렌더링 안정성(동작) 개선에 집중했으며 시각적 변경은 없습니다.
- 관련 문서는 확인했으며 이번 변경에 반영할 문서 파일은 없었습니다.

### Testing
- 빌드: `pnpm build`를 실행했고 UI 및 서비스 워크스페이스 빌드가 성공했습니다.
- 린트: `pnpm lint`(`svelte-check`/`tsc`)를 실행했고 0개의 에러/경고가 보고되었습니다.
- 테스트: `pnpm test`를 실행했고 Vitest에서 모든 테스트가 통과하여 (`Test Files 53 passed`, `Tests 235 passed`) 성공했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956328a1c4c832c8e15070bb6319568)