### PR TITLE
Wizard 모달 백드롭 닫기 추가 및 힌트 버블 비활성화

### DIFF
--- a/packages/ui/src/lib/components/WizardModal.svelte
+++ b/packages/ui/src/lib/components/WizardModal.svelte
@@ -4,7 +4,21 @@
   let { onclose } = $props<{ onclose: () => void }>();
 </script>
 
-<div class="modal-backdrop">
+<div
+  class="modal-backdrop"
+  role="button"
+  tabindex="0"
+  onclick={(event) => {
+    if (event.currentTarget === event.target) {
+      onclose();
+    }
+  }}
+  onkeydown={(event) => {
+    if (event.key === 'Escape' || event.key === 'Enter' || event.key === ' ') {
+      onclose();
+    }
+  }}
+>
   <div class="modal-content">
     <button class="close-btn" onclick={onclose} aria-label="Close">×</button>
     <SetupWizard mode="add" />

--- a/packages/ui/src/lib/views/Dashboard.svelte
+++ b/packages/ui/src/lib/views/Dashboard.svelte
@@ -12,7 +12,6 @@
   import RecentActivity from '../components/RecentActivity.svelte';
   import SetupWizard from '../components/SetupWizard.svelte';
   import WizardModal from '../components/WizardModal.svelte';
-  import HintBubble from '$lib/components/HintBubble.svelte';
   import Toggle from '$lib/components/Toggle.svelte';
   import PortToolbar from '$lib/components/PortToolbar.svelte';
   import { t } from 'svelte-i18n';
@@ -76,7 +75,6 @@
   // App.svelte에서 이미 dashboardEntities로 포트별 필터링을 완료하여 전달하므로,
   // 여기서는 전달받은 entities를 그대로 사용합니다.
   const visibleEntities = $derived.by<UnifiedEntity[]>(() => entities);
-  let hintDismissed = $state(false);
   let showAddBridgeModal = $state(false);
 
   // portStatuses에서 해당 포트의 상태를 가져오는 헬퍼 함수
@@ -193,11 +191,6 @@
       class="toggle-container"
       style="position: relative; display: flex; justify-content: flex-end;"
     >
-      {#if hasInactiveEntities && !hintDismissed}
-        <HintBubble onDismiss={() => (hintDismissed = true)}>
-          {$t('dashboard.hint_inactive_performance')}
-        </HintBubble>
-      {/if}
       <Toggle
         checked={showInactive}
         onchange={onToggleInactive}


### PR DESCRIPTION
### Motivation
- Wizard 모달의 UX를 개선하기 위해 백드롭 클릭으로 모달을 닫을 수 있게 하고 키보드로도 닫히도록 접근성을 보완했습니다.
- 대시보드에서 표시되는 힌트 버블(`bubbleHint`)을 비활성화하여 불필요한 안내 문구 노출을 줄입니다.

### Description
- `packages/ui/src/lib/components/WizardModal.svelte`에 백드롭 클릭 시 닫기 처리와 `Escape`/`Enter`/`Space` 키로 닫기 처리 및 `role`/`tabindex`를 추가해 접근성 이벤트를 처리하도록 변경했습니다.
- 백드롭 클릭은 내부 컨텐츠 클릭과 구분하기 위해 `event.currentTarget === event.target` 검사로만 닫히게 구현했습니다.
- `packages/ui/src/lib/views/Dashboard.svelte`에서 `HintBubble` 임포트 및 렌더링을 제거하여 힌트 버블을 비활성화했습니다.
- 기존의 닫기 버튼(`close-btn`) 동작은 유지했습니다.

### Testing
- `pnpm build`를 실행했으며 UI 빌드 및 서비스 정적 동기화가 성공적으로 완료되었습니다.
- `pnpm lint`를 실행했고 Svelte 진단 및 타입 체크가 문제없이 완료되었습니다.
- `pnpm test`를 실행한 결과 자동화 테스트가 모두 통과했으며 총 `53`개의 테스트 파일과 `235`개의 테스트가 성공했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69568a7152c4832ca67297dace1f3943)