### PR TITLE
힌트 버블 정렬 및 갤러리 카드 모바일 오버플로우 수정

### DIFF
--- a/packages/ui/src/lib/components/GalleryItemCard.svelte
+++ b/packages/ui/src/lib/components/GalleryItemCard.svelte
@@ -115,6 +115,7 @@
     flex-direction: column;
     gap: 0.75rem;
     transition: all 0.2s;
+    min-width: 0;
   }
 
   .card:hover {
@@ -135,6 +136,7 @@
     color: #f1f5f9;
     margin: 0;
     line-height: 1.3;
+    overflow-wrap: anywhere;
   }
 
   .version {
@@ -151,6 +153,7 @@
     color: #94a3b8;
     margin: 0;
     line-height: 1.5;
+    overflow-wrap: anywhere;
     display: -webkit-box;
     line-clamp: 2;
     -webkit-line-clamp: 2;
@@ -168,6 +171,7 @@
   .meta-row {
     display: flex;
     gap: 0.5rem;
+    flex-wrap: wrap;
   }
 
   .label {
@@ -176,6 +180,7 @@
 
   .value {
     color: #94a3b8;
+    overflow-wrap: anywhere;
   }
 
   .content-summary {

--- a/packages/ui/src/lib/components/HintBubble.svelte
+++ b/packages/ui/src/lib/components/HintBubble.svelte
@@ -16,7 +16,7 @@
 
   let bubbleEl: HTMLDivElement;
   let position = $state<'top' | 'bottom'>('top');
-  let horizontalAlign = $state<'left' | 'right'>('left');
+  let horizontalAlign = $state<'left' | 'right'>('right');
   let autoCloseTimer: ReturnType<typeof setTimeout> | null = null;
 
   onMount(async () => {
@@ -54,9 +54,9 @@
     }
 
     // 수평 위치 조정: 왼쪽으로 잘리면 왼쪽 정렬로 변경
-    if (rect.left < 0) {
+    if (rect.right > viewportWidth) {
       horizontalAlign = 'left';
-    } else if (rect.right > viewportWidth) {
+    } else if (rect.left < 0) {
       horizontalAlign = 'right';
     }
   }


### PR DESCRIPTION
### Motivation
- 비활성화 엔티티의 힌트 버블이 오른쪽에 표시되어야 하는데 왼쪽에 나오던 문제를 수정하기 위해 변경했습니다.
- 갤러리 목록에서 설명이 길어질 때 모바일 화면에서 카드가 가로로 넘치는 문제를 방지하기 위해 스타일을 보강했습니다.

### Description
- `packages/ui/src/lib/components/HintBubble.svelte`에서 기본 `horizontalAlign`을 `right`로 변경하고 `adjustPosition`의 화면 경계 검사 순서를 보정하여 힌트 버블이 우측에 우선 정렬되도록 수정했습니다.
- `packages/ui/src/lib/components/GalleryItemCard.svelte`에 카드 축소 허용을 위한 `min-width: 0`을 추가하고 제목/설명/메타 텍스트에 `overflow-wrap: anywhere`를 적용하여 긴 텍스트가 줄바꿈되도록 했습니다.
- 동일 파일에서 `.meta-row`에 `flex-wrap: wrap`을 추가해 메타 정보가 좁은 화면에서 줄바꿈되도록 처리했습니다.
- 변경된 파일: `packages/ui/src/lib/components/HintBubble.svelte` 및 `packages/ui/src/lib/components/GalleryItemCard.svelte`.

### Testing
- 빌드: `pnpm build`을 실행했고 UI 빌드 및 서비스 정적 동기화가 성공했습니다.
- 린트: `pnpm lint`를 실행했고 `svelte-check`/`tsc --noEmit`에서 오류 및 경고가 없었습니다.
- 테스트: `pnpm test`로 Vitest 전체 테스트를 실행했고 자동화된 테스트가 모두 통과했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69578488f728832cb5b207a9a593d800)