### PR TITLE
light·fan 엔티티에 낙관적(on/off) 상태 즉시 반영 추가

### DIFF
--- a/docs/config-schema/common-entity-options.md
+++ b/docs/config-schema/common-entity-options.md
@@ -80,6 +80,7 @@ light:
 - **기본값**: `false`
 - **설명**: `true`로 설정하면 명령 전송 즉시 UI 상태가 업데이트됩니다.
     - 실제 장치의 응답 속도가 느릴 때 UI 반응성을 높이는 데 유용합니다.
+    - `switch`, `light`, `fan`처럼 `on`/`off` 명령이 있는 엔티티는 `optimistic` 모드에서 즉시 `ON`/`OFF` 상태를 반영합니다.
     - `command_on`/`command_off` 등이 정의되지 않은 경우, 패킷을 전송하지 않고 상태만 유지하는 **가상 스위치(Virtual Switch)** 또는 플래그로 활용할 수 있습니다.
 
 ```yaml

--- a/packages/core/src/protocol/devices/fan.device.ts
+++ b/packages/core/src/protocol/devices/fan.device.ts
@@ -147,4 +147,14 @@ export class FanDevice extends GenericDevice {
 
     return null;
   }
+
+  public getOptimisticState(commandName: string, value?: any): Record<string, any> | null {
+    if (commandName === 'on') {
+      return { state: 'ON' };
+    }
+    if (commandName === 'off') {
+      return { state: 'OFF' };
+    }
+    return null;
+  }
 }

--- a/packages/core/src/protocol/devices/light.device.ts
+++ b/packages/core/src/protocol/devices/light.device.ts
@@ -161,4 +161,14 @@ export class LightDevice extends GenericDevice {
 
     return null;
   }
+
+  public getOptimisticState(commandName: string, value?: any): Record<string, any> | null {
+    if (commandName === 'on') {
+      return { state: 'ON' };
+    }
+    if (commandName === 'off') {
+      return { state: 'OFF' };
+    }
+    return null;
+  }
 }


### PR DESCRIPTION
### Motivation
- 현재 `optimistic` 옵션은 주로 스위치 용도로 사용되었으나 `on`/`off`를 가진 다른 엔티티에도 동일한 UX가 필요합니다.
- 조명과 팬도 `optimistic: true` 설정 시 즉시 `ON`/`OFF` 상태를 반영하도록 하여 UI 반응성을 개선합니다.
- 기존 `switch`의 동작과 일관된 낙관적 업데이트 동작을 제공하려는 목적입니다.
- 문서에 이 동작을 명시하여 사용자 설정 혼동을 줄입니다.

### Description
- `LightDevice`와 `FanDevice`에 `getOptimisticState`를 추가하여 `on`/`off` 명령에서 각각 `{ state: 'ON' }` / `{ state: 'OFF' }`를 반환하도록 구현했습니다 (`packages/core/src/protocol/devices/light.device.ts`, `packages/core/src/protocol/devices/fan.device.ts`).
- `PacketProcessor`의 기존 낙관적 처리 경로(`entity.optimistic` 체크 및 즉시 `state` 이벤트 발행)를 그대로 활용해 흐름 변경 없이 동작합니다.
- 문서 `docs/config-schema/common-entity-options.md`에 `switch` 외에 `light`/`fan`도 `optimistic` 모드에서 즉시 `ON`/`OFF`를 반영함을 명시했습니다.
- 변경 파일: `packages/core/src/protocol/devices/light.device.ts`, `packages/core/src/protocol/devices/fan.device.ts`, `docs/config-schema/common-entity-options.md`.

### Testing
- `pnpm build`를 실행하여 빌드가 성공적으로 완료되었음을 확인했습니다.
- `pnpm lint`를 실행하여 타입체크 및 Svelte 체크가 통과함을 확인했습니다.
- `pnpm test`로 Vitest 전체 테스트를 실행했으며 테스트 결과 모든 테스트가 통과(`267 passed`)했습니다.
- 변경으로 인한 자동화/기존 테스트의 회귀는 발견되지 않았습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e1f513610832c8d5d44d9a43e9201)