### PR TITLE
정리: serials 잔여 사용 제거

### DIFF
--- a/packages/core/test/automation/wait_until.test.ts
+++ b/packages/core/test/automation/wait_until.test.ts
@@ -21,7 +21,6 @@ describe('wait_until action', () => {
       parity: 'none',
       stop_bits: 1,
     },
-    serials: [],
     binary_sensor: [
       {
         id: 'test_sensor',

--- a/packages/core/test/protocol/checksum_generation.test.ts
+++ b/packages/core/test/protocol/checksum_generation.test.ts
@@ -20,7 +20,6 @@ describe('Command Generator - Checksum Logic', () => {
         parity: 'none',
         stop_bits: 1,
       },
-      serials: [],
       packet_defaults: defaults,
     }) as unknown as HomenetBridgeConfig;
 

--- a/packages/service/src/raw-packet-logger.service.ts
+++ b/packages/service/src/raw-packet-logger.service.ts
@@ -52,12 +52,10 @@ export class RawPacketLoggerService {
           `Log Started: ${new Date().toISOString()}`,
           `Log Mode: ${this.logMode === 'valid' ? 'valid-only' : 'all'}`,
           `Config Files: ${Array.isArray(meta.configFiles) ? meta.configFiles.join(', ') : 'N/A'}`,
-          'Serials:',
-          ...(Array.isArray(meta.serials)
-            ? meta.serials.map(
-              (s: any) => ` - ${s.portId}: ${s.path} (Baud: ${s.baudRate || 'N/A'})`,
-            )
-            : [' - N/A']),
+          'Serial:',
+          meta.serial
+            ? ` - ${meta.serial.portId}: ${meta.serial.path} (Baud: ${meta.serial.baudRate || 'N/A'})`
+            : ' - N/A',
           'Packet Stats:',
           ...(meta.stats
             ? Object.entries(meta.stats).map(

--- a/packages/service/src/routes/logs.routes.ts
+++ b/packages/service/src/routes/logs.routes.ts
@@ -89,9 +89,14 @@ export function createLogsRoutes(ctx: LogsRoutesContext): Router {
             const bridges = ctx.getBridges();
 
             // Gather Metadata
-            const serials = currentConfigs
-                .flatMap((conf) => conf.serials || [])
-                .map((s) => ({ portId: s.portId, path: s.path, baudRate: s.baud_rate }));
+            const serial = currentConfigs
+                .map((conf) => conf?.serial)
+                .filter((serial): serial is NonNullable<typeof serial> => Boolean(serial))
+                .map((serial) => ({
+                    portId: serial.portId,
+                    path: serial.path,
+                    baudRate: serial.baud_rate,
+                }))[0] ?? null;
 
             // Prefer UI-provided stats (accumulated on client-side) over server-side stats
             let stats: Record<string, any> = {};
@@ -108,7 +113,7 @@ export function createLogsRoutes(ctx: LogsRoutesContext): Router {
 
             const meta = {
                 configFiles: currentConfigFiles,
-                serials,
+                serial,
                 stats,
             };
 

--- a/packages/service/src/routes/packets.routes.ts
+++ b/packages/service/src/routes/packets.routes.ts
@@ -19,12 +19,11 @@ function findBridgeInstanceByPortId(
     portId: string,
 ): BridgeInstance | undefined {
     for (const instance of bridges) {
-        const serials = instance.config.serials || [];
-        for (let i = 0; i < serials.length; i++) {
-            const pId = normalizePortId(serials[i].portId, i);
-            if (pId === portId) {
-                return instance;
-            }
+        const serial = instance.config.serial;
+        if (!serial) continue;
+        const pId = normalizePortId(serial.portId, 0);
+        if (pId === portId) {
+            return instance;
         }
     }
     return undefined;

--- a/packages/service/src/routes/setup.routes.ts
+++ b/packages/service/src/routes/setup.routes.ts
@@ -97,8 +97,6 @@ export function createSetupRoutes(ctx: SetupRoutesContext): Router {
 
                 if (bridgeObj.serial && typeof bridgeObj.serial === 'object') {
                     serialConfig = bridgeObj.serial as Record<string, unknown>;
-                } else if (Array.isArray(bridgeObj.serials) && bridgeObj.serials.length > 0) {
-                    serialConfig = bridgeObj.serials[0] as Record<string, unknown>;
                 }
 
                 const packetDefaults = bridgeObj.packet_defaults || DEFAULT_PACKET_DEFAULTS;
@@ -425,16 +423,6 @@ export function createSetupRoutes(ctx: SetupRoutesContext): Router {
 
                 updatedYaml = dumpConfigToYaml(parsedConfig, { lineWidth: 120 });
 
-                const bridgeConfigForCleanup =
-                    (parsedConfig as any).homenet_bridge ||
-                    (parsedConfig as any).homenetBridge ||
-                    parsedConfig;
-
-                if (bridgeConfigForCleanup && typeof bridgeConfigForCleanup === 'object') {
-                    delete bridgeConfigForCleanup.serials;
-                }
-
-                updatedYaml = dumpConfigToYaml(parsedConfig, { lineWidth: 120 });
             }
 
             await fs.mkdir(configDir, { recursive: true });

--- a/packages/service/src/routes/system.routes.ts
+++ b/packages/service/src/routes/system.routes.ts
@@ -183,7 +183,7 @@ export function createSystemRoutes(ctx: SystemRoutesContext): Router {
             if (configError || !config || !config.serial) {
                 return {
                     configFile,
-                    serials: [],
+                    serial: null,
                     mqttTopicPrefix: BASE_MQTT_PREFIX,
                     topic: `${BASE_MQTT_PREFIX}/homedevice1/raw`,
                     error: configError || 'Config not loaded',
@@ -192,20 +192,18 @@ export function createSystemRoutes(ctx: SystemRoutesContext): Router {
             }
 
             const pId = normalizePortId(config.serial.portId, 0);
-            const serialTopics = [
-                {
-                    portId: pId,
-                    path: config.serial.path,
-                    baudRate: config.serial.baud_rate,
-                    topic: `${BASE_MQTT_PREFIX}/${pId}`,
-                },
-            ];
+            const serialInfo = {
+                portId: pId,
+                path: config.serial.path,
+                baudRate: config.serial.baud_rate,
+                topic: `${BASE_MQTT_PREFIX}/${pId}`,
+            };
 
             return {
                 configFile,
-                serials: serialTopics,
+                serial: serialInfo,
                 mqttTopicPrefix: BASE_MQTT_PREFIX,
-                topic: `${serialTopics[0]?.topic || `${BASE_MQTT_PREFIX}/homedevice1`}/raw`,
+                topic: `${serialInfo?.topic || `${BASE_MQTT_PREFIX}/homedevice1`}/raw`,
                 error: configError || undefined,
                 status: configStatus,
             };

--- a/packages/service/src/types/index.ts
+++ b/packages/service/src/types/index.ts
@@ -19,9 +19,7 @@ export type ConfigStatus = 'idle' | 'starting' | 'started' | 'error' | 'stopped'
 
 // --- Config Types ---
 
-export type PersistableHomenetBridgeConfig = Omit<HomenetBridgeConfig, 'serials'> & {
-    serials?: HomenetBridgeConfig['serials'];
-};
+export type PersistableHomenetBridgeConfig = HomenetBridgeConfig;
 
 export type BackupFileInfo = {
     filename: string;

--- a/packages/service/src/websocket/packet-stream.ts
+++ b/packages/service/src/websocket/packet-stream.ts
@@ -32,10 +32,10 @@ export function createPacketStreamHandler(ctx: PacketStreamContext) {
     const rebuildPortMappings = () => {
         const nextMap = new Map<string, string>();
         ctx.getCurrentConfigs().forEach((config) => {
-            config.serials?.forEach((serial: SerialConfig, index: number) => {
-                const portId = normalizePortId(serial.portId, index);
-                nextMap.set(portId, portId);
-            });
+            const serial = config.serial as SerialConfig | undefined;
+            if (!serial) return;
+            const portId = normalizePortId(serial.portId, 0);
+            nextMap.set(portId, portId);
         });
         state.topicPrefixToPortId = nextMap;
     };

--- a/packages/ui/src/App.svelte
+++ b/packages/ui/src/App.svelte
@@ -281,7 +281,7 @@
 
   const getKnownPortIds = () =>
     bridgeInfo?.bridges?.reduce<string[]>(
-      (acc, bridge) => acc.concat(bridge.serials.map((serial) => serial.portId)),
+      (acc, bridge) => (bridge.serial ? acc.concat(bridge.serial.portId) : acc),
       [],
     ) ?? [];
   // portId는 명시적으로 전달받은 값만 사용합니다. 추론하여 기본값으로 대체하지 않습니다.
@@ -530,7 +530,7 @@
 
       const portIds =
         data.bridges?.reduce<string[]>(
-          (acc, bridge) => acc.concat(bridge.serials.map((serial) => serial.portId)),
+          (acc, bridge) => (bridge.serial ? acc.concat(bridge.serial.portId) : acc),
           [],
         ) ?? [];
       const defaultPortId = portIds[0] ?? null;
@@ -1096,7 +1096,7 @@
 
     // 1. Flatten all ports from all bridges
     const allPorts = bridgeInfo.bridges.reduce<PortMetadata[]>((acc, bridge) => {
-      if (bridge.serials.length === 0 && (bridge.error || bridge.status === 'error')) {
+      if (!bridge.serial && (bridge.error || bridge.status === 'error')) {
         // Serials가 없지만 에러가 있는 경우, placeholder 포트를 추가하여 UI 탭에 표시되도록 함
         return acc.concat([
           {
@@ -1110,14 +1110,18 @@
           },
         ]);
       }
-      return acc.concat(
-        bridge.serials.map((serial) => ({
-          ...serial,
-          configFile: bridge.configFile,
-          error: bridge.error,
-          status: bridge.status,
-        })),
-      );
+      if (bridge.serial) {
+        return acc.concat([
+          {
+            ...bridge.serial,
+            configFile: bridge.configFile,
+            error: bridge.error,
+            status: bridge.status,
+          },
+        ]);
+      }
+
+      return acc;
     }, []);
 
     // 2. Deduplicate by portId

--- a/packages/ui/src/lib/types.ts
+++ b/packages/ui/src/lib/types.ts
@@ -82,7 +82,7 @@ export type BridgeSerialInfo = {
 
 export type BridgeEntry = {
   configFile: string;
-  serials: BridgeSerialInfo[];
+  serial: BridgeSerialInfo | null;
   mqttTopicPrefix: string;
   topic: string;
   error?: string;

--- a/packages/ui/src/lib/views/Gallery.svelte
+++ b/packages/ui/src/lib/views/Gallery.svelte
@@ -49,7 +49,8 @@
   // Extract ports from bridgeInfo for the modal
   const ports = $derived(
     bridgeInfo?.bridges?.reduce<{ portId: string; path: string }[]>(
-      (acc, bridge) => acc.concat(bridge.serials.map((s) => ({ portId: s.portId, path: s.path }))),
+      (acc, bridge) =>
+        bridge.serial ? acc.concat({ portId: bridge.serial.portId, path: bridge.serial.path }) : acc,
       [],
     ) ?? [],
   );

--- a/packages/ui/src/lib/views/Settings.svelte
+++ b/packages/ui/src/lib/views/Settings.svelte
@@ -1000,9 +1000,9 @@
               <div class="bridge-info">
                 <span class="file-name">{bridge.configFile}</span>
                 <div class="bridge-details">
-                  {#each bridge.serials as serial, index (`${serial.portId}-${index}`)}
-                    <span class="badge sm">{serial.portId}: {serial.path}</span>
-                  {/each}
+                  {#if bridge.serial}
+                    <span class="badge sm">{bridge.serial.portId}: {bridge.serial.path}</span>
+                  {/if}
                 </div>
               </div>
 


### PR DESCRIPTION
### Motivation
- 기존 코드에 남아있던 `serials`(배열) 관련 처리들을 제거하고 단일 `serial` 흐름으로 통일하기 위한 변경입니다.
- 서비스, 웹소켓 스트림, 로그 및 UI가 단일 시리얼 모델을 가정하도록 정리하여 혼란을 제거하려고 했습니다.
- 설정 생성/선택/테스트 흐름에서 레거시 `serials` 처리로 인한 예외 가능성을 없애기 위함입니다.
- 관련 단위 테스트에서 불필요한 `serials` 입력을 제거하여 테스트 의도를 명확히 했습니다.

### Description
- 서비스(`packages/service`)에서 `serials` 배열 사용을 제거하고 `serial` 단일 객체를 사용하도록 `setup.service.ts`, `setup.routes.ts`, `packets.routes.ts`, `logs.routes.ts`, `system.routes.ts`, `websocket/packet-stream.ts` 등을 수정했습니다.
- 타입 정의에서 `PersistableHomenetBridgeConfig`를 `HomenetBridgeConfig`로 단순화하고 관련 타입을 단일 `serial` 모델에 맞게 변경했습니다 (`packages/service/src/types/index.ts`).
- 원시 패킷 로거 헤더와 로그 메타데이터를 배열 기반에서 단일 `serial` 기반으로 변경했습니다 (`raw-packet-logger.service.ts`).
- UI(`packages/ui`)의 타입과 렌더/로직을 단일 `serial` 모델에 맞게 업데이트하여 `App.svelte`, `Gallery.svelte`, `Settings.svelte`, `lib/types.ts` 등을 수정했습니다.
- core 패키지의 테스트(예: `checksum_generation.test.ts`, `wait_until.test.ts`)에서 불필요한 `serials` 필드를 제거했습니다.

### Testing
- 빌드: `pnpm build`를 실행했고 빌드가 성공했습니다.
- 린트: `pnpm lint`를 실행했고 린트(타입체크 및 svelte-check)가 통과했습니다.
- 테스트: `pnpm test`로 전체 Vitest 테스트 스위트를 실행했고 모든 테스트가 성공(270 tests passed)했습니다.
- 변경 후 UI가 정상 동작하는지 빠른 확인을 위해 `pnpm --filter @rs485-homenet/ui dev`로 개발서버를 띄워 스크린샷을 생성해 UI 반영을 확인했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960a2b0ac04832c9681eace5b39fce8)