### PR TITLE
rawPacketLogger.getFilePath 반환 타입에 null 허용

### DIFF
--- a/packages/service/src/routes/logs.routes.ts
+++ b/packages/service/src/routes/logs.routes.ts
@@ -20,7 +20,7 @@ export interface LogsRoutesContext {
     getStatus: () => any;
     start: (meta: any, options: any) => void;
     stop: () => any;
-    getFilePath: (filename: string) => string;
+    getFilePath: (filename: string) => string | null;
   };
   logRetentionService: LogRetentionService;
   logCollectorService: {


### PR DESCRIPTION
### Motivation

- 빌드 중 `getFilePath` 할당에서 `string | null`이 `string`에 할당되지 않는 TypeScript 오류를 해결하기 위해 타입을 정렬합니다.
- 로그 파일이 존재하지 않을 때 경로를 `null`로 반환하는 구현과 라우트 컨텍스트 타입을 일치시켜 안정성을 높입니다.

### Description

- `LogsRoutesContext.rawPacketLogger.getFilePath` 반환 타입을 `string`에서 `string | null`로 변경했습니다.
- 변경 파일: `packages/service/src/routes/logs.routes.ts`.

### Testing

- `pnpm build`를 실행했고 빌드가 성공했습니다.
- `pnpm lint`를 실행했고 린트가 통과했습니다.
- `pnpm test`를 실행했고 전체 테스트 스위트가 성공적으로 통과했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69638674e194832c977ecf39a8a44391)