### PR TITLE
로그 보관 설정을 프론트엔드 설정 파일에 저장

### DIFF
--- a/packages/service/src/routes/logs.routes.ts
+++ b/packages/service/src/routes/logs.routes.ts
@@ -10,6 +10,7 @@ import type { RateLimiter } from '../utils/rate-limiter.js';
 import type { RawPacketLoggerService } from '../raw-packet-logger.service.js';
 import type { LogRetentionService } from '../log-retention.service.js';
 import { CONFIG_INIT_MARKER } from '../utils/constants.js';
+import { loadFrontendSettings, saveFrontendSettings } from '../services/frontend-settings.service.js';
 import { fileExists } from '../utils/helpers.js';
 import type { RawPacketStreamMode, BridgeInstance } from '../types/index.js';
 
@@ -213,6 +214,11 @@ export function createLogsRoutes(ctx: LogsRoutesContext): Router {
 
       await ctx.logRetentionService.updateSettings(settings);
       const newSettings = ctx.logRetentionService.getSettings();
+      const frontendSettings = await loadFrontendSettings();
+      await saveFrontendSettings({
+        ...frontendSettings,
+        logRetention: newSettings,
+      });
       res.json({ settings: newSettings });
     } catch (error) {
       logger.error({ err: error }, '[service] Failed to update cache settings');


### PR DESCRIPTION
### Motivation
- 앱 재시작 시 로그 보관(`logRetention`) 설정이 초기화되어 사용자가 변경한 값이 유지되지 않는 문제를 해결하기 위해 변경했습니다.
- 프론트엔드가 초기 로드 시 `frontend-setting.json`에서 설정을 읽으므로 `logRetention`을 이 파일에 저장하면 재시작 후에도 설정이 유지됩니다.

### Description
- `packages/service/src/routes/logs.routes.ts`에서 `loadFrontendSettings`와 `saveFrontendSettings`를 임포트하고 사용하도록 추가했습니다.
- `/api/logs/cache/settings` 엔드포인트에서 `LogRetentionService.updateSettings` 호출 후 현재 `frontend-setting.json`을 불러와 `logRetention` 필드를 갱신하여 저장하도록 처리했습니다.
- API 동작 방식과 응답 형식에는 변경을 가하지 않고 설정의 영속성만 추가했습니다.

### Testing
- `pnpm build`를 실행하여 전체 빌드가 성공했음을 확인했습니다 (`UI` 정적 파일을 `service/static`으로 동기화 포함). 
- `pnpm lint`를 실행하여 타입 검사 및 `svelte-check` 경고/오류 없이 완료했습니다.
- `pnpm test`로 Vitest 전체 스위트를 실행했으며 자동화된 테스트가 모두 성공하여 통과했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964519e1858832c8b27f15394a91948)