### PR TITLE
대시보드 엔티티 ID에 타입/카테고리 접두사 표시

### DIFF
--- a/packages/ui/src/lib/components/EntityCard.svelte
+++ b/packages/ui/src/lib/components/EntityCard.svelte
@@ -43,6 +43,12 @@
       onSelect?.();
     }
   }
+
+  function formatEntityId(entityInfo: UnifiedEntity): string {
+    const categoryPrefix = entityInfo.category && entityInfo.category !== 'entity';
+    const prefix = categoryPrefix ? entityInfo.category : entityInfo.type;
+    return prefix ? `${prefix}.${entityInfo.id}` : entityInfo.id;
+  }
 </script>
 
 <div
@@ -64,7 +70,7 @@
         <span class="entity-type-badge script">{$t('dashboard.entity_card.script_badge')}</span>
       {/if}
     </div>
-    <span class="entity-id-badge">{entity.id}</span>
+    <span class="entity-id-badge">{formatEntityId(entity)}</span>
   </header>
 
   <div class="card-body">


### PR DESCRIPTION
### Motivation
- 대시보드의 엔티티 ID 표시에 타입 또는 카테고리 접두사를 붙여 동일한 ID가 다른 타입/카테고리에서 혼동되는 문제를 줄이고 식별성을 개선합니다.

### Description
- `packages/ui/src/lib/components/EntityCard.svelte`에 `formatEntityId` 함수를 추가하고 엔티티 카드의 기존 `{entity.id}` 표시를 `{formatEntityId(entity)}`로 교체하여 엔티티가 카테고리(`automation`/`script` 등)이면 카테고리 접두사를, 그렇지 않으면 `entity.type`을 접두사로 사용해 `prefix.id` 형식으로 표시하도록 변경했습니다.

### Testing
- 변경 후 자동화된 검증으로 `pnpm build`가 성공했으며 `pnpm lint`가 경고/오류 없이 통과했고 `pnpm test`에서 전체 테스트가 성공하여 총 `63`개의 테스트 파일, `295`개의 테스트가 모두 통과했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696744f47210832cada159a5bd4b0bee)