### PR TITLE
브리지 에러 페이로드 표준화 및 상태/오류 전파 (서비스 · 코어 · UI)

### DIFF
--- a/packages/service/src/types/index.ts
+++ b/packages/service/src/types/index.ts
@@ -16,6 +16,19 @@ export type BridgeInstance = {
 
 export type BridgeStatus = 'idle' | 'starting' | 'started' | 'stopped' | 'error' | 'reconnecting';
 export type ConfigStatus = 'idle' | 'starting' | 'started' | 'error' | 'stopped' | 'reconnecting';
+export type BridgeErrorSource = 'serial' | 'core' | 'mqtt' | 'service';
+export type BridgeErrorSeverity = 'error' | 'warning';
+
+export type BridgeErrorPayload = {
+  code: string;
+  message?: string;
+  detail?: string;
+  source: BridgeErrorSource;
+  portId?: string;
+  severity: BridgeErrorSeverity;
+  retryable?: boolean;
+  timestamp: string;
+};
 
 // --- Config Types ---
 

--- a/packages/service/src/utils/bridge-errors.ts
+++ b/packages/service/src/utils/bridge-errors.ts
@@ -1,0 +1,150 @@
+import type {
+  BridgeErrorPayload,
+  BridgeErrorSeverity,
+  BridgeErrorSource,
+} from '../types/index.js';
+
+const normalizeMessage = (value: unknown): string => {
+  if (value instanceof Error) return value.message;
+  if (typeof value === 'string') return value;
+  if (value && typeof (value as { message?: string }).message === 'string') {
+    return (value as { message: string }).message;
+  }
+  return JSON.stringify(value);
+};
+
+export const createBridgeErrorPayload = ({
+  code,
+  message,
+  detail,
+  source,
+  portId,
+  severity = 'error',
+  retryable = true,
+}: {
+  code: string;
+  message?: string;
+  detail?: string;
+  source: BridgeErrorSource;
+  portId?: string;
+  severity?: BridgeErrorSeverity;
+  retryable?: boolean;
+}): BridgeErrorPayload => ({
+  code,
+  message,
+  detail,
+  source,
+  portId,
+  severity,
+  retryable,
+  timestamp: new Date().toISOString(),
+});
+
+export const formatBridgeErrorMessage = (error?: BridgeErrorPayload | string | null): string => {
+  if (!error) return '';
+  if (typeof error === 'string') return error;
+  return error.message || error.detail || error.code;
+};
+
+export const mapSerialError = (error: unknown, portId?: string): BridgeErrorPayload => {
+  const message = normalizeMessage(error);
+  const code = (error as { code?: string })?.code;
+  let errorCode = 'SERIAL_CONNECT_FAILED';
+
+  if (message.includes('유효한 path가 필요')) {
+    errorCode = 'SERIAL_PATH_MISSING';
+  } else if (code === 'ENOENT') {
+    errorCode = 'SERIAL_PATH_NOT_FOUND';
+  } else if (code === 'EACCES') {
+    errorCode = 'SERIAL_PERMISSION_DENIED';
+  } else if (code === 'EBUSY') {
+    errorCode = 'SERIAL_PORT_BUSY';
+  }
+
+  return createBridgeErrorPayload({
+    code: errorCode,
+    message,
+    detail: code,
+    source: 'serial',
+    portId,
+    severity: 'error',
+    retryable: true,
+  });
+};
+
+export const mapConfigLoadError = (error: unknown, portId?: string): BridgeErrorPayload => {
+  const message = normalizeMessage(error);
+  return createBridgeErrorPayload({
+    code: 'CORE_CONFIG_LOAD_FAILED',
+    message,
+    detail: message,
+    source: 'core',
+    portId,
+    severity: 'error',
+    retryable: false,
+  });
+};
+
+export const mapMqttError = (error: unknown, portId?: string): BridgeErrorPayload => {
+  const message = normalizeMessage(error);
+  const code = (error as { code?: string })?.code;
+  let errorCode = 'MQTT_CONNECT_FAILED';
+
+  if (message.toLowerCase().includes('not authorized')) {
+    errorCode = 'MQTT_AUTH_FAILED';
+  } else if (
+    code &&
+    ['ECONNREFUSED', 'ENOTFOUND', 'ETIMEDOUT', 'EAI_AGAIN'].includes(code)
+  ) {
+    errorCode = 'MQTT_CONNECT_FAILED';
+  }
+
+  return createBridgeErrorPayload({
+    code: errorCode,
+    message,
+    detail: code,
+    source: 'mqtt',
+    portId,
+    severity: 'error',
+    retryable: true,
+  });
+};
+
+export const mapMqttDisconnect = (portId?: string): BridgeErrorPayload => {
+  return createBridgeErrorPayload({
+    code: 'MQTT_DISCONNECTED',
+    message: 'MQTT connection lost',
+    source: 'mqtt',
+    portId,
+    severity: 'warning',
+    retryable: true,
+  });
+};
+
+export const mapBridgeStartError = (error: unknown, portId?: string): BridgeErrorPayload => {
+  const message = normalizeMessage(error);
+  const code = (error as { code?: string })?.code;
+  const serialErrorCodes = ['ENOENT', 'EACCES', 'EBUSY'];
+
+  if (
+    message.includes('serial(') ||
+    message.includes('시리얼') ||
+    (code && serialErrorCodes.includes(code))
+  ) {
+    return mapSerialError(error, portId);
+  }
+
+  if (message.toLowerCase().includes('mqtt')) {
+    return mapMqttError(error, portId);
+  }
+
+  return createBridgeErrorPayload({
+    code: 'CORE_START_FAILED',
+    message,
+    detail: message,
+    source: 'core',
+    portId,
+    severity: 'error',
+    retryable: true,
+  });
+};

--- a/packages/ui/src/lib/components/PortToolbar.svelte
+++ b/packages/ui/src/lib/components/PortToolbar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { BridgeStatus } from '../types';
+  import type { BridgeErrorPayload, BridgeStatus } from '../types';
   import { t } from 'svelte-i18n';
   import HintBubble from './HintBubble.svelte';
 
@@ -13,7 +13,12 @@
   }: {
     portIds: string[];
     activePortId: string | null;
-    portStatuses?: { portId: string; status: BridgeStatus | 'unknown'; message?: string }[];
+    portStatuses?: {
+      portId: string;
+      status: BridgeStatus | 'unknown';
+      message?: string;
+      errorInfo?: BridgeErrorPayload | null;
+    }[];
     showAddButton?: boolean;
     onPortChange?: (portId: string) => void;
     onAddBridge?: () => void;
@@ -23,17 +28,33 @@
 
   function getPortStatus(portId: string): BridgeStatus | 'unknown' {
     const portStatus = portStatuses.find(
-      (p: { portId: string; status: BridgeStatus | 'unknown'; message?: string }) =>
-        p.portId === portId,
+      (p: {
+        portId: string;
+        status: BridgeStatus | 'unknown';
+        message?: string;
+        errorInfo?: BridgeErrorPayload | null;
+      }) => p.portId === portId,
     );
     return portStatus?.status ?? 'unknown';
   }
 
   function getPortErrorMessage(portId: string): string | undefined {
     const portStatus = portStatuses.find(
-      (p: { portId: string; status: BridgeStatus | 'unknown'; message?: string }) =>
-        p.portId === portId,
+      (p: {
+        portId: string;
+        status: BridgeStatus | 'unknown';
+        message?: string;
+        errorInfo?: BridgeErrorPayload | null;
+      }) => p.portId === portId,
     );
+    if (portStatus?.errorInfo) {
+      return $t(`errors.${portStatus.errorInfo.code}`, {
+        default:
+          portStatus.errorInfo.message ||
+          portStatus.errorInfo.detail ||
+          portStatus.errorInfo.code,
+      });
+    }
     return portStatus?.message;
   }
 

--- a/packages/ui/src/lib/i18n/locales/en.json
+++ b/packages/ui/src/lib/i18n/locales/en.json
@@ -579,6 +579,11 @@
     "INITIALIZATION_NOT_ALLOWED": "Initialization has already been completed.",
     "INVALID_FILENAME": "Invalid filename.",
     "SERIAL_PATH_REQUIRED": "Serial port path is required.",
+    "SERIAL_PATH_MISSING": "Serial port path is required.",
+    "SERIAL_PATH_NOT_FOUND": "Serial port path was not found.",
+    "SERIAL_PERMISSION_DENIED": "Permission denied for serial port.",
+    "SERIAL_PORT_BUSY": "Serial port is in use by another process.",
+    "SERIAL_CONNECT_FAILED": "Failed to connect to the serial port.",
     "EXAMPLE_NOT_FOUND": "Example configuration file not found.",
     "EXAMPLE_READ_FAILED": "Failed to read example configuration file.",
     "SERIAL_CONFIG_MISSING": "Serial configuration is missing from the config file.",
@@ -590,7 +595,13 @@
     "SERIAL_PARITY_INVALID": "Check the parity setting.",
     "SERIAL_STOP_BITS_INVALID": "Check the stop bits setting.",
     "SERIAL_PATH_DUPLICATE": "The serial path is already in use. Please choose another path.",
-    "PORT_ID_DUPLICATE": "The port ID is already in use. Please enter a different ID."
+    "PORT_ID_DUPLICATE": "The port ID is already in use. Please enter a different ID.",
+    "CORE_CONFIG_LOAD_FAILED": "Failed to load configuration file.",
+    "CORE_NO_VALID_CONFIG": "All configuration files failed to load.",
+    "CORE_START_FAILED": "Failed to start the bridge.",
+    "MQTT_CONNECT_FAILED": "Failed to connect to the MQTT broker.",
+    "MQTT_AUTH_FAILED": "MQTT authentication failed.",
+    "MQTT_DISCONNECTED": "MQTT connection lost."
   },
   "setup_wizard": {
     "title": "Initial Setup",

--- a/packages/ui/src/lib/i18n/locales/ko.json
+++ b/packages/ui/src/lib/i18n/locales/ko.json
@@ -582,6 +582,11 @@
     "INITIALIZATION_NOT_ALLOWED": "이미 초기화가 완료되었습니다.",
     "INVALID_FILENAME": "잘못된 파일명입니다.",
     "SERIAL_PATH_REQUIRED": "시리얼 포트 경로를 입력해주세요.",
+    "SERIAL_PATH_MISSING": "시리얼 포트 경로가 필요합니다.",
+    "SERIAL_PATH_NOT_FOUND": "시리얼 포트 경로를 찾을 수 없습니다.",
+    "SERIAL_PERMISSION_DENIED": "시리얼 포트 접근 권한이 없습니다.",
+    "SERIAL_PORT_BUSY": "시리얼 포트가 다른 프로세스에서 사용 중입니다.",
+    "SERIAL_CONNECT_FAILED": "시리얼 포트 연결에 실패했습니다.",
     "EXAMPLE_NOT_FOUND": "예제 설정 파일을 찾을 수 없습니다.",
     "EXAMPLE_READ_FAILED": "예제 설정 파일을 읽을 수 없습니다.",
     "SERIAL_CONFIG_MISSING": "설정 파일에 serial 설정이 없습니다.",
@@ -593,7 +598,13 @@
     "SERIAL_PARITY_INVALID": "패리티 설정을 확인해주세요.",
     "SERIAL_STOP_BITS_INVALID": "스톱 비트 설정을 확인해주세요.",
     "SERIAL_PATH_DUPLICATE": "이미 사용 중인 시리얼 경로입니다. 다른 경로를 선택해주세요.",
-    "PORT_ID_DUPLICATE": "이미 사용 중인 포트 ID입니다. 다른 ID를 입력해주세요."
+    "PORT_ID_DUPLICATE": "이미 사용 중인 포트 ID입니다. 다른 ID를 입력해주세요.",
+    "CORE_CONFIG_LOAD_FAILED": "설정 파일을 불러오지 못했습니다.",
+    "CORE_NO_VALID_CONFIG": "모든 설정 파일을 불러오지 못했습니다.",
+    "CORE_START_FAILED": "브릿지 시작에 실패했습니다.",
+    "MQTT_CONNECT_FAILED": "MQTT 브로커 연결에 실패했습니다.",
+    "MQTT_AUTH_FAILED": "MQTT 인증에 실패했습니다.",
+    "MQTT_DISCONNECTED": "MQTT 연결이 끊어졌습니다."
   },
   "setup_wizard": {
     "title": "초기 설정",

--- a/packages/ui/src/lib/types.ts
+++ b/packages/ui/src/lib/types.ts
@@ -92,6 +92,19 @@ export interface ActivityLog {
 }
 
 export type BridgeStatus = 'idle' | 'starting' | 'started' | 'stopped' | 'error' | 'reconnecting';
+export type BridgeErrorSource = 'serial' | 'core' | 'mqtt' | 'service';
+export type BridgeErrorSeverity = 'error' | 'warning';
+
+export type BridgeErrorPayload = {
+  code: string;
+  message?: string;
+  detail?: string;
+  source: BridgeErrorSource;
+  portId?: string;
+  severity: BridgeErrorSeverity;
+  retryable?: boolean;
+  timestamp: string;
+};
 
 export type BridgeSerialInfo = {
   portId: string;
@@ -106,6 +119,7 @@ export type BridgeEntry = {
   mqttTopicPrefix: string;
   topic: string;
   error?: string;
+  errorInfo?: BridgeErrorPayload | null;
   status: 'idle' | 'starting' | 'started' | 'error' | 'stopped';
 };
 
@@ -115,6 +129,7 @@ export type BridgeInfo = {
   mqttUrl: string;
   status: BridgeStatus;
   error?: string | null;
+  errorInfo?: BridgeErrorPayload | null;
   topic: string;
   restartRequired?: boolean;
   timezone?: string;

--- a/packages/ui/src/lib/views/Gallery.svelte
+++ b/packages/ui/src/lib/views/Gallery.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { t } from 'svelte-i18n';
   import { onMount } from 'svelte';
-  import type { BridgeSerialInfo, BridgeStatus } from '../types';
+  import type { BridgeErrorPayload, BridgeSerialInfo, BridgeStatus } from '../types';
   import GalleryItemCard from '../components/GalleryItemCard.svelte';
   import GalleryPreviewModal from '../components/GalleryPreviewModal.svelte';
   import PortToolbar from '../components/PortToolbar.svelte';
@@ -76,7 +76,12 @@
     onPortChange,
   }: {
     portMetadata: Array<BridgeSerialInfo & { configFile: string }>;
-    portStatuses?: { portId: string; status: BridgeStatus | 'unknown'; message?: string }[];
+    portStatuses?: {
+      portId: string;
+      status: BridgeStatus | 'unknown';
+      message?: string;
+      errorInfo?: BridgeErrorPayload | null;
+    }[];
     selectedPortId: string | null;
     onPortChange?: (portId: string) => void;
   } = $props();


### PR DESCRIPTION
### Motivation
- 브리지(시리얼/코어/MQTT) 오류와 상태를 일관된 페이로드로 표준화해 서비스와 UI 간에 명확하게 전달하기 위함.
- UI에서 오류 코드를 기반으로 지역화된 메시지를 보여주고 WebSocket 스트림으로 MQTT 연결 상태를 실시간 반영하기 위함.

### Description
- 신규 유틸 `packages/service/src/utils/bridge-errors.ts`를 추가해 `BridgeErrorPayload` 생성기와 시리얼/구성/MQTT 관련 매핑 함수를 제공하도록 했습니다 (`createBridgeErrorPayload`, `mapSerialError`, `mapConfigLoadError`, `mapMqttError`, `mapMqttDisconnect`, `mapBridgeStartError`).
- 서비스 타입에 `BridgeErrorPayload`를 추가하고 서버 상태 관리에서 기존 문자열 오류를 해당 페이로드로 교체해 `/api/bridge/info` 응답에 `errorInfo`를 포함하도록 확장했습니다 (`packages/service/src/types/index.ts`, `packages/service/src/server.ts`, `packages/service/src/routes/system.routes.ts`).
- 코어에서 MQTT 클라이언트 이벤트를 수집하여 `eventBus`로 `mqtt:status`, `mqtt:error`, `mqtt:disconnected` 이벤트를 발행하고, 서비스의 WebSocket 스트림 핸들러가 이를 받아 `status` 스트림 이벤트로 클라이언트에 전달하도록 연결했습니다 (`packages/core/src/service/bridge.service.ts`, `packages/service/src/websocket/packet-stream.ts`).
- UI에서 수신한 `errorInfo`를 기반으로 에러 코드에 매핑된 지역화 메시지를 표시하도록 변경하고 관련 컴포넌트와 타입을 업데이트했으며 오류 메시지 키들을 한/영 i18n 파일에 추가했습니다 (`packages/ui/src/App.svelte`, `packages/ui/src/lib/views/Dashboard.svelte`, `packages/ui/src/lib/components/PortToolbar.svelte`, `packages/ui/src/lib/types.ts`, `packages/ui/src/lib/i18n/locales/*.json`).
- 컨트롤/명령 경로에서 브리지 에러 페이로드를 포맷해 사용자에게 더 친절한 오류를 반환하도록 수정했습니다 (`packages/service/src/routes/controls.routes.ts`).

### Testing
- 빌드: `pnpm build`을 실행해 프로젝트 빌드 및 UI 정적 자산 동기화가 성공했습니다.
- 린트: `pnpm lint`를 실행했고 에러 없이 통과했습니다.
- 단위/통합 테스트: `pnpm test`를 실행해 테스트 스위트가 통과했으며 총 `316`개의 테스트가 성공적으로 완료되었습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b32dac6a8832c8733a3d7308044d9)