### PR TITLE
kocom 갤러리 템플릿의 CEL `has()` 검사 수정

### DIFF
--- a/gallery/kocom/lights_new.yaml
+++ b/gallery/kocom/lights_new.yaml
@@ -84,15 +84,15 @@ entities:
             data: [0x00]
           command_on: >-
             [[0x30, 0xBC, 0x00, 0x0E, {{room.room_idx}}, 0x01, 0x00, 0x00, 0xFF,
-            has(states['room_{{room.room_idx}}_light_2']) && states['room_{{room.room_idx}}_light_2']['state'] == 'ON' ? 0xFF : 0x00,
-            has(states['room_{{room.room_idx}}_light_3']) && states['room_{{room.room_idx}}_light_3']['state'] == 'ON' ? 0xFF : 0x00,
-            has(states['room_{{room.room_idx}}_light_4']) && states['room_{{room.room_idx}}_light_4']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_light_2']['state']) && states['room_{{room.room_idx}}_light_2']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_light_3']['state']) && states['room_{{room.room_idx}}_light_3']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_light_4']['state']) && states['room_{{room.room_idx}}_light_4']['state'] == 'ON' ? 0xFF : 0x00,
             0, 0, 0, 0], [0x30, 0xDC]]
           command_off: >-
             [[0x30, 0xBC, 0x00, 0x0E, {{room.room_idx}}, 0x01, 0x00, 0x00, 0x00,
-            has(states['room_{{room.room_idx}}_light_2']) && states['room_{{room.room_idx}}_light_2']['state'] == 'ON' ? 0xFF : 0x00,
-            has(states['room_{{room.room_idx}}_light_3']) && states['room_{{room.room_idx}}_light_3']['state'] == 'ON' ? 0xFF : 0x00,
-            has(states['room_{{room.room_idx}}_light_4']) && states['room_{{room.room_idx}}_light_4']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_light_2']['state']) && states['room_{{room.room_idx}}_light_2']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_light_3']['state']) && states['room_{{room.room_idx}}_light_3']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_light_4']['state']) && states['room_{{room.room_idx}}_light_4']['state'] == 'ON' ? 0xFF : 0x00,
             0, 0, 0, 0], [0x30, 0xDC]]
 
         # Light 2 (offset 9)
@@ -110,17 +110,17 @@ entities:
             data: [0x00]
           command_on: >-
             [[0x30, 0xBC, 0x00, 0x0E, {{room.room_idx}}, 0x01, 0x00, 0x00,
-            has(states['room_{{room.room_idx}}_light_1']) && states['room_{{room.room_idx}}_light_1']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_light_1']['state']) && states['room_{{room.room_idx}}_light_1']['state'] == 'ON' ? 0xFF : 0x00,
             0xFF,
-            has(states['room_{{room.room_idx}}_light_3']) && states['room_{{room.room_idx}}_light_3']['state'] == 'ON' ? 0xFF : 0x00,
-            has(states['room_{{room.room_idx}}_light_4']) && states['room_{{room.room_idx}}_light_4']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_light_3']['state']) && states['room_{{room.room_idx}}_light_3']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_light_4']['state']) && states['room_{{room.room_idx}}_light_4']['state'] == 'ON' ? 0xFF : 0x00,
             0, 0, 0, 0], [0x30, 0xDC]]
           command_off: >-
             [[0x30, 0xBC, 0x00, 0x0E, {{room.room_idx}}, 0x01, 0x00, 0x00,
-            has(states['room_{{room.room_idx}}_light_1']) && states['room_{{room.room_idx}}_light_1']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_light_1']['state']) && states['room_{{room.room_idx}}_light_1']['state'] == 'ON' ? 0xFF : 0x00,
             0x00,
-            has(states['room_{{room.room_idx}}_light_3']) && states['room_{{room.room_idx}}_light_3']['state'] == 'ON' ? 0xFF : 0x00,
-            has(states['room_{{room.room_idx}}_light_4']) && states['room_{{room.room_idx}}_light_4']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_light_3']['state']) && states['room_{{room.room_idx}}_light_3']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_light_4']['state']) && states['room_{{room.room_idx}}_light_4']['state'] == 'ON' ? 0xFF : 0x00,
             0, 0, 0, 0], [0x30, 0xDC]]
 
         # Light 3 (offset 10)
@@ -138,17 +138,17 @@ entities:
             data: [0x00]
           command_on: >-
             [[0x30, 0xBC, 0x00, 0x0E, {{room.room_idx}}, 0x01, 0x00, 0x00,
-            has(states['room_{{room.room_idx}}_light_1']) && states['room_{{room.room_idx}}_light_1']['state'] == 'ON' ? 0xFF : 0x00,
-            has(states['room_{{room.room_idx}}_light_2']) && states['room_{{room.room_idx}}_light_2']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_light_1']['state']) && states['room_{{room.room_idx}}_light_1']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_light_2']['state']) && states['room_{{room.room_idx}}_light_2']['state'] == 'ON' ? 0xFF : 0x00,
             0xFF,
-            has(states['room_{{room.room_idx}}_light_4']) && states['room_{{room.room_idx}}_light_4']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_light_4']['state']) && states['room_{{room.room_idx}}_light_4']['state'] == 'ON' ? 0xFF : 0x00,
             0, 0, 0, 0], [0x30, 0xDC]]
           command_off: >-
             [[0x30, 0xBC, 0x00, 0x0E, {{room.room_idx}}, 0x01, 0x00, 0x00,
-            has(states['room_{{room.room_idx}}_light_1']) && states['room_{{room.room_idx}}_light_1']['state'] == 'ON' ? 0xFF : 0x00,
-            has(states['room_{{room.room_idx}}_light_2']) && states['room_{{room.room_idx}}_light_2']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_light_1']['state']) && states['room_{{room.room_idx}}_light_1']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_light_2']['state']) && states['room_{{room.room_idx}}_light_2']['state'] == 'ON' ? 0xFF : 0x00,
             0x00,
-            has(states['room_{{room.room_idx}}_light_4']) && states['room_{{room.room_idx}}_light_4']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_light_4']['state']) && states['room_{{room.room_idx}}_light_4']['state'] == 'ON' ? 0xFF : 0x00,
             0, 0, 0, 0], [0x30, 0xDC]]
 
         # Light 4 (offset 11)
@@ -166,13 +166,13 @@ entities:
             data: [0x00]
           command_on: >-
             [[0x30, 0xBC, 0x00, 0x0E, {{room.room_idx}}, 0x01, 0x00, 0x00,
-            has(states['room_{{room.room_idx}}_light_1']) && states['room_{{room.room_idx}}_light_1']['state'] == 'ON' ? 0xFF : 0x00,
-            has(states['room_{{room.room_idx}}_light_2']) && states['room_{{room.room_idx}}_light_2']['state'] == 'ON' ? 0xFF : 0x00,
-            has(states['room_{{room.room_idx}}_light_3']) && states['room_{{room.room_idx}}_light_3']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_light_1']['state']) && states['room_{{room.room_idx}}_light_1']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_light_2']['state']) && states['room_{{room.room_idx}}_light_2']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_light_3']['state']) && states['room_{{room.room_idx}}_light_3']['state'] == 'ON' ? 0xFF : 0x00,
             0xFF, 0, 0, 0, 0], [0x30, 0xDC]]
           command_off: >-
             [[0x30, 0xBC, 0x00, 0x0E, {{room.room_idx}}, 0x01, 0x00, 0x00,
-            has(states['room_{{room.room_idx}}_light_1']) && states['room_{{room.room_idx}}_light_1']['state'] == 'ON' ? 0xFF : 0x00,
-            has(states['room_{{room.room_idx}}_light_2']) && states['room_{{room.room_idx}}_light_2']['state'] == 'ON' ? 0xFF : 0x00,
-            has(states['room_{{room.room_idx}}_light_3']) && states['room_{{room.room_idx}}_light_3']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_light_1']['state']) && states['room_{{room.room_idx}}_light_1']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_light_2']['state']) && states['room_{{room.room_idx}}_light_2']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_light_3']['state']) && states['room_{{room.room_idx}}_light_3']['state'] == 'ON' ? 0xFF : 0x00,
             0x00, 0, 0, 0, 0], [0x30, 0xDC]]

--- a/gallery/kocom/outlets.yaml
+++ b/gallery/kocom/outlets.yaml
@@ -86,15 +86,15 @@ entities:
             data: [0x00]
           command_on: >-
             [[0x30, 0xBC, 0x00, 0x3B, {{room.room_idx}}, 0x01, 0x00, 0x00, 0xFF,
-            has(states['room_{{room.room_idx}}_outlet_2']) && states['room_{{room.room_idx}}_outlet_2']['state'] == 'ON' ? 0xFF : 0x00,
-            has(states['room_{{room.room_idx}}_outlet_3']) && states['room_{{room.room_idx}}_outlet_3']['state'] == 'ON' ? 0xFF : 0x00,
-            has(states['room_{{room.room_idx}}_outlet_4']) && states['room_{{room.room_idx}}_outlet_4']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_outlet_2']['state']) && states['room_{{room.room_idx}}_outlet_2']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_outlet_3']['state']) && states['room_{{room.room_idx}}_outlet_3']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_outlet_4']['state']) && states['room_{{room.room_idx}}_outlet_4']['state'] == 'ON' ? 0xFF : 0x00,
             0, 0, 0, 0], [0x30, 0xDC]]
           command_off: >-
             [[0x30, 0xBC, 0x00, 0x3B, {{room.room_idx}}, 0x01, 0x00, 0x00, 0x00,
-            has(states['room_{{room.room_idx}}_outlet_2']) && states['room_{{room.room_idx}}_outlet_2']['state'] == 'ON' ? 0xFF : 0x00,
-            has(states['room_{{room.room_idx}}_outlet_3']) && states['room_{{room.room_idx}}_outlet_3']['state'] == 'ON' ? 0xFF : 0x00,
-            has(states['room_{{room.room_idx}}_outlet_4']) && states['room_{{room.room_idx}}_outlet_4']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_outlet_2']['state']) && states['room_{{room.room_idx}}_outlet_2']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_outlet_3']['state']) && states['room_{{room.room_idx}}_outlet_3']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_outlet_4']['state']) && states['room_{{room.room_idx}}_outlet_4']['state'] == 'ON' ? 0xFF : 0x00,
             0, 0, 0, 0], [0x30, 0xDC]]
 
         # Outlet 2 (offset 9)
@@ -113,17 +113,17 @@ entities:
             data: [0x00]
           command_on: >-
             [[0x30, 0xBC, 0x00, 0x3B, {{room.room_idx}}, 0x01, 0x00, 0x00,
-            has(states['room_{{room.room_idx}}_outlet_1']) && states['room_{{room.room_idx}}_outlet_1']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_outlet_1']['state']) && states['room_{{room.room_idx}}_outlet_1']['state'] == 'ON' ? 0xFF : 0x00,
             0xFF,
-            has(states['room_{{room.room_idx}}_outlet_3']) && states['room_{{room.room_idx}}_outlet_3']['state'] == 'ON' ? 0xFF : 0x00,
-            has(states['room_{{room.room_idx}}_outlet_4']) && states['room_{{room.room_idx}}_outlet_4']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_outlet_3']['state']) && states['room_{{room.room_idx}}_outlet_3']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_outlet_4']['state']) && states['room_{{room.room_idx}}_outlet_4']['state'] == 'ON' ? 0xFF : 0x00,
             0, 0, 0, 0], [0x30, 0xDC]]
           command_off: >-
             [[0x30, 0xBC, 0x00, 0x3B, {{room.room_idx}}, 0x01, 0x00, 0x00,
-            has(states['room_{{room.room_idx}}_outlet_1']) && states['room_{{room.room_idx}}_outlet_1']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_outlet_1']['state']) && states['room_{{room.room_idx}}_outlet_1']['state'] == 'ON' ? 0xFF : 0x00,
             0x00,
-            has(states['room_{{room.room_idx}}_outlet_3']) && states['room_{{room.room_idx}}_outlet_3']['state'] == 'ON' ? 0xFF : 0x00,
-            has(states['room_{{room.room_idx}}_outlet_4']) && states['room_{{room.room_idx}}_outlet_4']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_outlet_3']['state']) && states['room_{{room.room_idx}}_outlet_3']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_outlet_4']['state']) && states['room_{{room.room_idx}}_outlet_4']['state'] == 'ON' ? 0xFF : 0x00,
             0, 0, 0, 0], [0x30, 0xDC]]
 
         # Outlet 3 (offset 10)
@@ -142,17 +142,17 @@ entities:
             data: [0x00]
           command_on: >-
             [[0x30, 0xBC, 0x00, 0x3B, {{room.room_idx}}, 0x01, 0x00, 0x00,
-            has(states['room_{{room.room_idx}}_outlet_1']) && states['room_{{room.room_idx}}_outlet_1']['state'] == 'ON' ? 0xFF : 0x00,
-            has(states['room_{{room.room_idx}}_outlet_2']) && states['room_{{room.room_idx}}_outlet_2']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_outlet_1']['state']) && states['room_{{room.room_idx}}_outlet_1']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_outlet_2']['state']) && states['room_{{room.room_idx}}_outlet_2']['state'] == 'ON' ? 0xFF : 0x00,
             0xFF,
-            has(states['room_{{room.room_idx}}_outlet_4']) && states['room_{{room.room_idx}}_outlet_4']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_outlet_4']['state']) && states['room_{{room.room_idx}}_outlet_4']['state'] == 'ON' ? 0xFF : 0x00,
             0, 0, 0, 0], [0x30, 0xDC]]
           command_off: >-
             [[0x30, 0xBC, 0x00, 0x3B, {{room.room_idx}}, 0x01, 0x00, 0x00,
-            has(states['room_{{room.room_idx}}_outlet_1']) && states['room_{{room.room_idx}}_outlet_1']['state'] == 'ON' ? 0xFF : 0x00,
-            has(states['room_{{room.room_idx}}_outlet_2']) && states['room_{{room.room_idx}}_outlet_2']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_outlet_1']['state']) && states['room_{{room.room_idx}}_outlet_1']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_outlet_2']['state']) && states['room_{{room.room_idx}}_outlet_2']['state'] == 'ON' ? 0xFF : 0x00,
             0x00,
-            has(states['room_{{room.room_idx}}_outlet_4']) && states['room_{{room.room_idx}}_outlet_4']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_outlet_4']['state']) && states['room_{{room.room_idx}}_outlet_4']['state'] == 'ON' ? 0xFF : 0x00,
             0, 0, 0, 0], [0x30, 0xDC]]
 
         # Outlet 4 (offset 11)
@@ -171,13 +171,13 @@ entities:
             data: [0x00]
           command_on: >-
             [[0x30, 0xBC, 0x00, 0x3B, {{room.room_idx}}, 0x01, 0x00, 0x00,
-            has(states['room_{{room.room_idx}}_outlet_1']) && states['room_{{room.room_idx}}_outlet_1']['state'] == 'ON' ? 0xFF : 0x00,
-            has(states['room_{{room.room_idx}}_outlet_2']) && states['room_{{room.room_idx}}_outlet_2']['state'] == 'ON' ? 0xFF : 0x00,
-            has(states['room_{{room.room_idx}}_outlet_3']) && states['room_{{room.room_idx}}_outlet_3']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_outlet_1']['state']) && states['room_{{room.room_idx}}_outlet_1']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_outlet_2']['state']) && states['room_{{room.room_idx}}_outlet_2']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_outlet_3']['state']) && states['room_{{room.room_idx}}_outlet_3']['state'] == 'ON' ? 0xFF : 0x00,
             0xFF, 0, 0, 0, 0], [0x30, 0xDC]]
           command_off: >-
             [[0x30, 0xBC, 0x00, 0x3B, {{room.room_idx}}, 0x01, 0x00, 0x00,
-            has(states['room_{{room.room_idx}}_outlet_1']) && states['room_{{room.room_idx}}_outlet_1']['state'] == 'ON' ? 0xFF : 0x00,
-            has(states['room_{{room.room_idx}}_outlet_2']) && states['room_{{room.room_idx}}_outlet_2']['state'] == 'ON' ? 0xFF : 0x00,
-            has(states['room_{{room.room_idx}}_outlet_3']) && states['room_{{room.room_idx}}_outlet_3']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_outlet_1']['state']) && states['room_{{room.room_idx}}_outlet_1']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_outlet_2']['state']) && states['room_{{room.room_idx}}_outlet_2']['state'] == 'ON' ? 0xFF : 0x00,
+            has(states['room_{{room.room_idx}}_outlet_3']['state']) && states['room_{{room.room_idx}}_outlet_3']['state'] == 'ON' ? 0xFF : 0x00,
             0x00, 0, 0, 0, 0], [0x30, 0xDC]]


### PR DESCRIPTION
### Motivation
- CEL 파서에서 `has()` 호출 인자가 올바르지 않아 실행 오류가 발생하여 갤러리 템플릿의 명령 생성 표현식을 안전하게 만들기 위해 수정했습니다.

### Description
- `gallery/kocom/lights_new.yaml` 및 `gallery/kocom/outlets.yaml`에서 `has(states['...'])` 표현을 `has(states['...']['state'])`로 변경하여 CEL에서 상태 필드 존재 여부를 올바르게 검사하도록 했습니다.

### Testing
- 로컬에서 `pnpm build` 및 `pnpm lint`를 실행하여 빌드와 린트는 성공했으며 `pnpm test`를 실행한 결과 일부 테스트(`packages/core/test/homenet2mqtt/kocom.test.ts` 등)와 예제 파일 의존성(`packages/core/config/examples/bestin2.0.homenet_bridge.yaml` 없음)으로 인해 테스트 스위트는 실패했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970aca1652c832c9c4e219902668a10)