### PR TITLE
패킷 해석 테스트 카드: 활성 포트 사용 및 버튼 스타일 정리

### DIFF
--- a/packages/ui/src/lib/components/analysis/PacketAnalyzerCard.svelte
+++ b/packages/ui/src/lib/components/analysis/PacketAnalyzerCard.svelte
@@ -8,20 +8,9 @@
   }>();
 
   let packetInput = $state('');
-  let selectedPortId = $state('');
   let isLoading = $state(false);
   let error = $state<string | null>(null);
   let result = $state<PacketAnalysisResult | null>(null);
-
-  $effect(() => {
-    if (!selectedPortId) {
-      selectedPortId = activePortId ?? portIds[0] ?? '';
-      return;
-    }
-    if (selectedPortId && !portIds.includes(selectedPortId)) {
-      selectedPortId = activePortId ?? portIds[0] ?? '';
-    }
-  });
 
   const formatState = (state: unknown) => {
     try {
@@ -45,10 +34,11 @@
     isLoading = true;
 
     try {
+      const targetPortId = activePortId ?? portIds[0] ?? '';
       const response = await fetch('./api/tools/packet/analyze', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ input: packetInput, portId: selectedPortId || undefined }),
+        body: JSON.stringify({ input: packetInput, portId: targetPortId || undefined }),
       });
       const payload = await response.json();
       if (!response.ok) {
@@ -73,19 +63,9 @@
   </div>
 
   <div class="card-body">
-    <div class="grid">
-      <label>
-        <span class="label">{$t('analysis.packet_analyzer.port_label')}</span>
-        <select bind:value={selectedPortId} disabled={portIds.length <= 1}>
-          {#each portIds as portId}
-            <option value={portId}>{portId}</option>
-          {/each}
-        </select>
-      </label>
-      <div class="format-hint">
-        <span class="label">{$t('analysis.packet_analyzer.format_label')}</span>
-        <span class="inline-hint">{$t('analysis.packet_analyzer.format_hint')}</span>
-      </div>
+    <div class="format-hint">
+      <span class="label">{$t('analysis.packet_analyzer.format_label')}</span>
+      <span class="inline-hint">{$t('analysis.packet_analyzer.format_hint')}</span>
     </div>
 
     <div class="form-row full">
@@ -289,12 +269,6 @@
     min-height: 110px;
   }
 
-  .grid {
-    display: grid;
-    gap: 1rem;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  }
-
   label {
     display: flex;
     flex-direction: column;
@@ -303,8 +277,7 @@
     font-size: 0.85rem;
   }
 
-  textarea,
-  select {
+  textarea {
     padding: 0.6rem 0.75rem;
     background: rgba(15, 23, 42, 0.7);
     border: 1px solid rgba(148, 163, 184, 0.2);
@@ -338,17 +311,17 @@
     gap: 1rem;
   }
 
-  button.primary {
-    border-radius: 999px;
-    padding: 0.55rem 1.5rem;
-    border: none;
-    background: #3b82f6;
-    color: #fff;
-    font-weight: 600;
+  .primary {
+    padding: 0.5rem 1rem;
+    border-radius: 8px;
+    border: 1px solid rgba(59, 130, 246, 0.6);
+    background: rgba(59, 130, 246, 0.2);
+    color: #bfdbfe;
     cursor: pointer;
+    font-weight: 600;
   }
 
-  button.primary:disabled {
+  .primary:disabled {
     opacity: 0.6;
     cursor: not-allowed;
   }


### PR DESCRIPTION
### Motivation
- 패킷 해석 테스트에서 불필요한 포트 선택 UI를 제거하고 항상 활성화된 포트(`activePortId`)를 사용하도록 단순화하며, 실행 버튼의 스타일을 다른 분석 카드와 일치시키기 위함입니다.

### Description
- `packages/ui/src/lib/components/analysis/PacketAnalyzerCard.svelte`에서 `selectedPortId`와 포트 선택 `<select>` UI를 제거했습니다.
- 해석 요청 시 포트는 `activePortId ?? portIds[0] ?? ''`로 결정하여 `targetPortId`로 API에 전달하도록 변경했습니다.
- 실행 버튼의 클래스/스타일을 기존 분석 카드의 `primary` 규칙과 동일하게 조정하여 시각적 불일치를 해소했습니다.
- 관련 불필요한 레이아웃/CSS (`.grid`, `select` 관련 스타일 등)를 정리했습니다.

### Testing
- 빌드: `pnpm build`를 실행하여 성공적으로 완료했습니다.
- 린트: `pnpm lint`를 실행하여 에러 없이 완료했습니다.
- 테스트: `pnpm test`를 실행했고 전체 자동화 테스트가 통과하여 모든 테스트가 성공했습니다 (`336 tests passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69755026f94c832cbea5550ab9454189)