### PR TITLE
패킷 로그 일시정지 버튼 레이아웃 수정

### DIFF
--- a/packages/ui/src/lib/components/PacketLog.svelte
+++ b/packages/ui/src/lib/components/PacketLog.svelte
@@ -224,6 +224,8 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    flex-wrap: wrap;
+    gap: 0.75rem;
     margin-bottom: 1rem;
   }
 
@@ -232,6 +234,7 @@
     align-items: center;
     gap: 1.5rem;
     flex-wrap: wrap; /* Handle small screens */
+    flex: 1 1 320px;
   }
 
   .description {
@@ -245,6 +248,11 @@
     align-items: center;
     font-size: 0.9rem;
     color: #94a3b8;
+    flex-wrap: wrap;
+  }
+
+  .search-box {
+    flex: 1 1 200px;
   }
 
   .search-box input {
@@ -254,7 +262,7 @@
     padding: 0.3rem 0.6rem;
     color: #e2e8f0;
     font-size: 0.85rem;
-    width: 200px;
+    width: 100%;
   }
 
   .search-box input:focus {
@@ -372,6 +380,13 @@
   .header-right {
     display: flex;
     align-items: center;
+  }
+
+  @media (max-width: 600px) {
+    .header-right {
+      width: 100%;
+      justify-content: flex-end;
+    }
   }
 
   .pause-btn {


### PR DESCRIPTION
### Motivation
- 모바일/좁은 화면에서 패킷 로그 헤더의 일시정지 버튼과 검색/필터 영역이 겹치거나 레이아웃이 깨지는 문제를 완화하기 위함.

### Description
- `packages/ui/src/lib/components/PacketLog.svelte`의 스타일을 조정하여 `.log-header`에 `flex-wrap`과 `gap`을 추가하고 헤더의 왼쪽 영역에 `flex: 1 1 320px`을 지정하여 줄바꿈을 허용했습니다.
- 필터 영역 `.filters`에 `flex-wrap`을 적용하고 검색 박스에 `flex` 기반 레이아웃을 부여하여 입력창이 작은 화면에서 전체 너비를 차지하도록 변경했습니다.
- 작은 화면을 위한 미디어 쿼리를 추가해 `.header-right`(일시정지 버튼 영역)가 전체 폭으로 내려가 우측 정렬되도록 했습니다.

### Testing
- `pnpm build`를 실행했으며 UI 및 서비스 빌드가 성공했습니다.
- `pnpm lint`를 실행했으며 `svelte-check` 및 타입체크에서 오류가 없었습니다.
- `pnpm test`를 실행했으며 Vitest 테스트 스위트가 성공적으로 완료되어 모든 테스트가 통과했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69754f8e3794832ca86d8ef404d078b3)