### PR TITLE
대시보드 검색 칩 추가

### DIFF
--- a/packages/ui/src/lib/i18n/locales/en.json
+++ b/packages/ui/src/lib/i18n/locales/en.json
@@ -455,6 +455,7 @@
     "show_automations": "Automations",
     "show_scripts": "Scripts",
     "show_inactive_entities": "Inactive items",
+    "search_placeholder": "Search by name or ID",
     "topology": {
       "serial_device": "RS485-serial",
       "mqtt_broker": "MQTT Broker",

--- a/packages/ui/src/lib/i18n/locales/ko.json
+++ b/packages/ui/src/lib/i18n/locales/ko.json
@@ -456,6 +456,7 @@
     "show_automations": "자동화",
     "show_scripts": "스크립트",
     "show_inactive_entities": "비활성화 항목",
+    "search_placeholder": "이름 또는 ID 검색",
     "topology": {
       "serial_device": "RS485 시리얼",
       "mqtt_broker": "MQTT 브로커",


### PR DESCRIPTION
### Motivation
- 대시보드 필터 영역에 빠르게 엔티티를 찾을 수 있는 최소한의 검색 UI를 추가해 탐색성을 개선하기 위해 변경했습니다.
- 검색은 현재 토글된 항목(엔티티/자동화/스크립트/비활성)을 반영해야 하며, 불필요한 빈번한 연산을 막기 위해 디바운스가 필요했습니다.

### Description
- 대시보드에 돋보기 아이콘 기반의 "검색 칩"을 추가하고 클릭/포커스로 입력창이 확장되도록 구현했습니다 (`packages/ui/src/lib/views/Dashboard.svelte`).
- 입력값은 250ms 디바운스를 적용해 `debouncedSearchText`로 처리하며, 검색은 `displayName`, `id`, `description`, `category`, `portId` 필드를 소문자 포함 텍스트로 매칭합니다.
- 토글 상태(`showEntities`, `showAutomations`, `showScripts`, `showInactive`)로 이미 필터링된 `visibleEntities` 위에서 검색을 수행하도록 `searchedEntities`를 사용하도록 변경했습니다.
- 접근성 개선을 위해 칩에 `role="button"`, `tabindex="0"`와 키보드 핸들러(`Enter`, `Space`)를 추가했고, 검색 placeholder 번역을 `ko.json`/`en.json`에 추가했습니다.

### Testing
- UI 빌드와 전체 빌드를 실행해 `pnpm build`가 성공함을 확인했습니다 (UI 번들 정상 생성). 
- 린트는 `pnpm lint`로 실행했고 `svelte-check`/`tsc --noEmit`에서 오류 없이 통과했습니다.
- 단위 테스트는 `pnpm test`로 실행했으며 전체 테스트 스위트가 성공적으로 통과했습니다 (`73 files, 336 tests` 모두 통과).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69754f351580832c8dbe0227d2982533)