### PR TITLE
대시보드 필터: 제목을 아이콘으로 교체하고 빈 상태/힌트 위치 개선

### DIFF
--- a/packages/ui/src/lib/i18n/locales/en.json
+++ b/packages/ui/src/lib/i18n/locales/en.json
@@ -472,7 +472,7 @@
       "title": "Recent Activity",
       "empty": "No recent activity."
     },
-    "no_devices_found": "No devices detected or commands configured for the selected port.",
+    "no_devices_found": "No items to display.",
     "hint_inactive_performance": "Deleting inactive entities can improve performance",
     "error_hint_restart": "A connection issue occurred. Please check your settings or refresh the page.",
     "entity_card": {

--- a/packages/ui/src/lib/i18n/locales/ko.json
+++ b/packages/ui/src/lib/i18n/locales/ko.json
@@ -473,7 +473,7 @@
       "title": "최근 활동",
       "empty": "최근 활동이 없습니다."
     },
-    "no_devices_found": "선택한 포트에서 감지된 장치나 설정된 명령이 없습니다.",
+    "no_devices_found": "표시할 항목이 없습니다.",
     "hint_inactive_performance": "비활성화 엔티티를 삭제하면 성능을 개선할 수 있습니다",
     "error_hint_restart": "연결 문제가 발생했습니다. 설정을 확인하거나 페이지를 새로고침해 주세요.",
     "entity_card": {

--- a/packages/ui/src/lib/views/Dashboard.svelte
+++ b/packages/ui/src/lib/views/Dashboard.svelte
@@ -330,13 +330,18 @@
       <!-- Toggle for Inactive Entities -->
       <div class="toggle-container" aria-label={$t('dashboard.filter_section_aria')}>
         <div class="toggle-header">
-          <span class="toggle-title">{$t('dashboard.filter_title')}</span>
+          <span class="toggle-title" aria-hidden="true">
+            <svg class="filter-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <path
+                d="M3 5h18l-7 8v5l-4 2v-7L3 5z"
+                stroke-width="2"
+                stroke-linejoin="round"
+                stroke-linecap="round"
+              />
+            </svg>
+          </span>
+          <span class="sr-only">{$t('dashboard.filter_title')}</span>
         </div>
-        {#if hasInactiveEntities && !hintDismissed}
-          <HintBubble onDismiss={() => (hintDismissed = true)} autoCloseMs={10000}>
-            {$t('dashboard.hint_inactive_performance')}
-          </HintBubble>
-        {/if}
         <div class="toggle-group">
           <div
             class="filter-chip search-chip"
@@ -388,15 +393,22 @@
           >
             {$t('dashboard.show_scripts')}
           </button>
-          <button
-            type="button"
-            class:active={showInactive}
-            class="filter-chip"
-            aria-pressed={showInactive}
-            onclick={() => onToggleInactive?.()}
-          >
-            {$t('dashboard.show_inactive_entities')}
-          </button>
+          <div class="inactive-chip-wrapper">
+            {#if hasInactiveEntities && !hintDismissed}
+              <HintBubble onDismiss={() => (hintDismissed = true)} autoCloseMs={10000}>
+                {$t('dashboard.hint_inactive_performance')}
+              </HintBubble>
+            {/if}
+            <button
+              type="button"
+              class:active={showInactive}
+              class="filter-chip"
+              aria-pressed={showInactive}
+              onclick={() => onToggleInactive?.()}
+            >
+              {$t('dashboard.show_inactive_entities')}
+            </button>
+          </div>
         </div>
       </div>
 
@@ -443,9 +455,29 @@
   }
 
   .toggle-title {
-    font-size: 0.85rem;
-    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.4rem;
+    height: 1.4rem;
     color: #e2e8f0;
+  }
+
+  .filter-icon {
+    width: 1.1rem;
+    height: 1.1rem;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   .toggle-group {
@@ -514,6 +546,12 @@
     background: rgba(59, 130, 246, 0.2);
     color: #eff6ff;
     box-shadow: 0 0 12px rgba(59, 130, 246, 0.2);
+  }
+
+  .inactive-chip-wrapper {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
   }
 
   .error {


### PR DESCRIPTION
### Motivation
- 필터 섹션의 UI 일관성과 가독성을 높이고 비활성화 엔티티 힌트가 관련 칩 위치에 정확히 표시되도록 수정하기 위함입니다.
- 엔티티가 없을 때의 안내 문구를 더 간결하고 명확하게 바꾸기 위함입니다.

### Description
- `packages/ui/src/lib/views/Dashboard.svelte`에서 필터 섹션 제목을 텍스트에서 필터 모양의 아이콘으로 교체하고 접근성용 숨김 텍스트(`.sr-only`)를 추가했습니다.
- 동일 파일에서 비활성화 엔티티 힌트(`HintBubble`)를 비활성화 칩을 감싸는 `.inactive-chip-wrapper`로 이동해 힌트가 칩 위치에 맞춰 나타나도록 레이아웃/CSS를 조정했습니다.
- 로케일 파일 `packages/ui/src/lib/i18n/locales/ko.json`와 `packages/ui/src/lib/i18n/locales/en.json`의 빈 상태 메시지를 각각 `"표시할 항목이 없습니다."`와 `"No items to display."`로 간결화했습니다.

### Testing
- `pnpm build`를 실행하여 UI와 Core 빌드가 성공했음을 확인했습니다 (UI 및 service 정적 파일 동기화 포함) — 성공.
- `pnpm lint`를 실행하여 `tsc --noEmit`와 `svelte-check` 결과에 오류/경고가 없음을 확인했습니다 — 성공.
- `pnpm test`를 실행하여 전체 테스트 스위트가 통과했음을 확인했으며 결과는 `Tests 336 passed (336)`입니다 — 성공.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975561ca8b8832ca6644978f36344ed)