### PR TITLE
패킷 로그 검색창 너비 조정 및 패킷 해석기 바이트 표시 제거

### DIFF
--- a/packages/ui/src/lib/components/PacketLog.svelte
+++ b/packages/ui/src/lib/components/PacketLog.svelte
@@ -262,7 +262,9 @@
   }
 
   .search-box {
-    flex: 1 1 200px;
+    flex: 0 1 240px;
+    min-width: 200px;
+    max-width: 280px;
   }
 
   .search-box input {
@@ -273,6 +275,13 @@
     color: #e2e8f0;
     font-size: 0.85rem;
     width: 100%;
+  }
+
+  @media (max-width: 640px) {
+    .search-box {
+      flex: 1 1 100%;
+      max-width: none;
+    }
   }
 
   .search-box input:focus {

--- a/packages/ui/src/lib/components/analysis/PacketAnalyzerCard.svelte
+++ b/packages/ui/src/lib/components/analysis/PacketAnalyzerCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { t } from 'svelte-i18n';
-  import type { PacketAnalysisResult, PacketAnalysisPacket } from '../../types';
+  import type { PacketAnalysisResult } from '../../types';
 
   let { portIds, activePortId } = $props<{
     portIds: string[];
@@ -19,8 +19,6 @@
       return String(state);
     }
   };
-
-  const formatBytes = (packet: PacketAnalysisPacket) => packet.bytes.join(', ');
 
   const handleAnalyze = async () => {
     error = null;
@@ -115,11 +113,6 @@
                     })}</span
                   >
                   <code>{packet.hex}</code>
-                </div>
-                <div class="packet-meta">
-                  <span class="badge"
-                    >{$t('analysis.packet_analyzer.bytes_label')}: {formatBytes(packet)}</span
-                  >
                 </div>
                 <div class="packet-section">
                   <div class="section-title">
@@ -378,10 +371,6 @@
     max-width: 100%;
     overflow-wrap: anywhere;
     word-break: break-all;
-  }
-
-  .packet-meta {
-    margin-top: 0.4rem;
   }
 
   .badge {


### PR DESCRIPTION
### Motivation
- 패킷로그 화면에서 검색 입력창의 폭을 조절해 모바일/작은 화면에서 레이아웃이 깨지는 문제를 개선합니다.
- 패킷 해석기에서 `바이트: [숫자배열]` 표시가 불필요하여 UI에서 제거합니다.

### Description
- `packages/ui/src/lib/components/PacketLog.svelte`에 검색 입력박스 스타일을 변경하여 `flex`, `min-width`, `max-width`를 추가하고 작은 화면용 미디어쿼리를 도입했습니다 (`.search-box` 관련 CSS 수정).
- `packages/ui/src/lib/components/analysis/PacketAnalyzerCard.svelte`에서 바이트 배열 표시 관련 `formatBytes` 헬퍼와 해당 뱃지를 제거하고 관련 타입 임포트에서 사용하지 않는 타입을 정리했습니다.
- 변경된 파일: `PacketLog.svelte`, `analysis/PacketAnalyzerCard.svelte`.

### Testing
- 빌드: `pnpm build`을 실행했고 UI와 서비스 빌드가 성공했습니다 (성공).
- 린트: `pnpm lint`를 실행했고 `tsc --noEmit` 및 `svelte-check` 결과 오류/경고 없음 (성공).
- 테스트: `pnpm test`로 Vitest 전체를 실행했고 전체 테스트 통과 (336개 테스트 전부 성공).

스크린샷: `artifacts/packet-log.png`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69759cc598e8832c95e3be28dd1f4c89)