### PR TITLE
모바일 토폴로지 카드 노드 간격 조정

### DIFF
--- a/packages/ui/src/lib/components/SystemTopology.svelte
+++ b/packages/ui/src/lib/components/SystemTopology.svelte
@@ -720,7 +720,7 @@
       flex: 1;
       padding-top: 0;
       gap: 0;
-      justify-content: space-between;
+      justify-content: flex-start;
     }
 
     .detail-spacer {
@@ -742,6 +742,7 @@
       flex-direction: row;
       flex-wrap: wrap;
       column-gap: 1rem;
+      min-height: 48px;
     }
 
     .details-column.left,


### PR DESCRIPTION
### Motivation
- 모바일 토폴로지 카드에서 노드 라벨이 서로 구분되도록 최소한의 세로 여백을 보장하면서 불필요한 높이를 제거해 그래픽 섹션 링크 길이가 유지되도록 조정합니다.

### Description
- `.details-section`의 정렬을 `space-between`에서 `flex-start`로 변경하고, 각 `.details-column`에 `min-height: 48px`를 추가해 모바일 레이아웃에서 노드 텍스트가 겹치지 않게 수정했습니다 (`packages/ui/src/lib/components/SystemTopology.svelte`).

### Testing
- 빌드: `pnpm build` 실행 및 성공 확인.
- 린트: `pnpm lint` 실행 및 성공 확인.
- 테스트: `pnpm test` 실행 결과 Vitest 전체가 성공(336 tests passed)했습니다.
- UI 스크린샷 시도(Playwright)는 Chromium 프로세스가 SIGSEGV로 종료되어 실패했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69759e6febe4832c87522e2c7dc9a1b6)