### PR TITLE
팬 장치: 헤더 포함 전체 패킷 기준 오프셋 적용

### DIFF
--- a/packages/core/config/examples/cvnet.homenet_bridge.yaml
+++ b/packages/core/config/examples/cvnet.homenet_bridge.yaml
@@ -95,10 +95,10 @@ homenet_bridge:
       state:
         data: [0x20, 0x01, 0x71]
       state_on:
-        offset: 4
+        offset: 5
         data: [0x01]
       state_off:
-        offset: 4
+        offset: 5
         data: [0x00]
       command_on:
         data: [0x20, 0x71, 0x01, 0x11, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00]
@@ -109,7 +109,7 @@ homenet_bridge:
       command_speed: >-
         [[0x20, 0x71, 0x01, 0x02, x, 0x00, 0x00], [0x60, 0x71, 0x01, 0x02, x]]
       state_speed:
-        offset: 6
+        offset: 7
         signed: False
 
   valve:

--- a/packages/core/src/protocol/devices/fan.device.ts
+++ b/packages/core/src/protocol/devices/fan.device.ts
@@ -14,7 +14,7 @@ export class FanDevice extends GenericDevice {
     }
     const updates = super.parseData(packet) || {};
     const headerLength = this.protocolConfig.packet_defaults?.rx_header?.length || 0;
-    const payload = packet.slice(headerLength);
+    const payload = packet;
     const normalized = normalizeDeviceState(
       { ...this.config, type: 'fan' } as FanEntity,
       payload,

--- a/packages/core/test/fan_custom_preset.test.ts
+++ b/packages/core/test/fan_custom_preset.test.ts
@@ -22,11 +22,11 @@ describe('Fan Preset Mode (CEL)', () => {
           data: [0x30, 0x01, 0x71],
         },
         state_on: {
-          offset: 4,
+          offset: 5,
           data: [0x01],
         },
         state_off: {
-          offset: 4,
+          offset: 5,
           data: [0x00],
         },
         preset_modes: ['Auto', 'Sleep', 'Turbo'],
@@ -63,11 +63,11 @@ describe('Fan Preset Mode (CEL)', () => {
           data: [0x30, 0x01, 0x71],
         },
         state_on: {
-          offset: 4,
+          offset: 5,
           data: [0x01],
         },
         state_off: {
-          offset: 4,
+          offset: 5,
           data: [0x00],
         },
         preset_modes: ['Low', 'Medium', 'High'],
@@ -76,10 +76,9 @@ describe('Fan Preset Mode (CEL)', () => {
 
       const device = new FanDevice(config, protocolConfig);
 
-      // Packet with state ON (payload[4]=0x01) and preset Medium (data[6]=0x02)
+      // Packet with state ON (full packet index 5 = 0x01) and preset Medium (data[6]=0x02)
       // Full packet: [header=0xf7, 0x30, 0x01, 0x71, 0x00, 0x01, 0x02, 0x00, 0xee]
-      // payload = [0x30, 0x01, 0x71, 0x00, 0x01, 0x02, 0x00] (after header)
-      // payload[4] = 0x01 (ON)
+      // Index 5 = 0x01 (ON)
       const packet = Buffer.from([0xf7, 0x30, 0x01, 0x71, 0x00, 0x01, 0x02, 0x00, 0xee]);
       const result = device.parseData(packet);
 
@@ -156,11 +155,11 @@ describe('Fan Preset Mode (CEL)', () => {
           data: [0x30, 0x01, 0x71],
         },
         state_on: {
-          offset: 4,
+          offset: 5,
           data: [0x01],
         },
         state_off: {
-          offset: 4,
+          offset: 5,
           data: [0x00],
         },
         command_on: {


### PR DESCRIPTION
### Motivation
- 팬 상태 파싱에서 오프셋을 계산할 때 헤더를 제거하지 않고 전체 패킷 인덱스 기준으로 읽어야 하는 요구에 대응하기 위해 변경했습니다.
- CVNet 예제 설정과 단위 테스트가 전체 패킷 기준 인덱스를 가정하고 있어 동기화가 필요했습니다.

### Description
- `FanDevice.parseData`를 변경해 페이로드를 `packet.slice(headerLength)`가 아닌 전체 `packet`으로 전달하도록 조정했습니다 (`packages/core/src/protocol/devices/fan.device.ts`).
- CVNet 예제 설정에서 팬 관련 상태 오프셋과 속도 인덱스를 전체 패킷 기준으로 맞추어 수정했습니다 (`packages/core/config/examples/cvnet.homenet_bridge.yaml`).
- 팬 프리셋 관련 단위 테스트의 오프셋과 주석을 전체 패킷 인덱스 기준으로 업데이트했습니다 (`packages/core/test/fan_custom_preset.test.ts`).

### Testing
- 빌드(`pnpm build`)를 실행하여 컴파일을 확인했고 성공했습니다.
- 린트(`pnpm lint`)를 실행하여 타입/검사 오류가 없는지 확인했고 성공했습니다.
- 테스트(`pnpm test`)를 실행했으며 전체 테스트 스위트가 성공적으로 통과했고 총 `73`개 파일, `336`개의 테스트가 통과했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975f3f53830832ca254686aece0f65c)