### PR TITLE
Fix Commax 스마트 콘센트 전력 센서 스키마 (state_value → state_number)

### DIFF
--- a/gallery/commax/smart_plugs_new.yaml
+++ b/gallery/commax/smart_plugs_new.yaml
@@ -3,7 +3,7 @@ meta:
   name_en: "Smart Plugs"
   description: "코맥스 스마트 콘센트 설정입니다. 개수를 지정할 수 있습니다. 전력 사용량 센서도 포함되어 있습니다."
   description_en: "Commax smart plugs with power consumption sensors. You can specify the count."
-  version: "2.0.0"
+  version: "2.0.1"
   author: "wooooooooooook"
   tags: ["switch", "plug", "outlet", "power", "sensor", "commax"]
 parameters:


### PR DESCRIPTION
### Motivation
- Commax 갤러리 스니펫의 전력 센서가 패킷 `F9 01 07 11 00 00 51 63` 등에서 올바르게 매칭/파싱되지 않아 스위치 상태와 달리 센서가 매칭되지 않는 문제를 해결하기 위해 변경했습니다.

### Description
- `gallery/commax/smart_plugs_new.yaml`의 센서 정의에서 `state_value` 를 바이너리 수치 추출용 `state_number`로 변경하여 `offset`, `length`, `decode: bcd`, `precision: 1`로 전력값을 올바르게 파싱하도록 수정했습니다.

### Testing
- 로컬에서 `pnpm build`, `pnpm lint`, `pnpm test`를 실행하여 빌드·린트·테스트가 모두 성공(`Test Files  72 passed`, `Tests  333 passed`)함을 확인했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977109ef3ec832c818cdf565332dab9)