### PR TITLE
현대 imazu 엘리베이터(2대) 갤러리 스니펫 업데이트

### DIFF
--- a/gallery/hyundai_imazu/elevator2.yaml
+++ b/gallery/hyundai_imazu/elevator2.yaml
@@ -1,11 +1,16 @@
 meta:
   name: "현대통신 엘리베이터 2대"
   name_en: "Hyundai Telecom Elevator x2"
-  description: "현대통신 월패드용 엘리베이터 2대가 있는 경우 호출 및 상태 확인 설정입니다."
-  description_en: "Elevator call and status configuration for Hyundai Telecom wallpads."
-  version: "1.0.2"
+  description: "현대통신 월패드용 엘리베이터 2대가 있는 경우 호출 및 상태 확인 설정입니다. 참고:https://yogyui.tistory.com/entry/%ED%98%84%EB%8C%80%ED%86%B5%EC%8B%A0-%EC%9B%94%ED%8C%A8%EB%93%9C-RS-485-%ED%86%B5%EC%8B%A0-%ED%94%84%EB%A1%9C%ED%86%A0%EC%BD%9C-%EC%97%98%EB%A6%AC%EB%B2%A0%EC%9D%B4%ED%84%B0-%ED%98%B8%EC%B6%9C"
+  description_en: "Elevator call and status configuration for Hyundai Telecom wallpads. Reference: https://yogyui.tistory.com/entry/%ED%98%84%EB%8C%80%ED%86%B5%EC%8B%A0-%EC%9B%94%ED%8C%A8%EB%93%9C-RS-485-%ED%86%B5%EC%8B%A0-%ED%94%84%EB%A1%9C%ED%86%A0%EC%BD%9C-%EC%97%98%EB%A6%AC%EB%B2%A0%EC%9D%B4%ED%84%B0-%ED%98%B8%EC%B6%9C"
+  version: "1.0.3"
   author: "wooooooooooook"
   tags: ["elevator", "hyundai", "imazu"]
+
+discovery:
+  match:
+    data: [0x0D, 0x01, 0x34, 0x01, 0x41]
+    mask: [0x00, 0xff, 0xff, 0xff, 0xff]
 
 scripts:
   - id: 'elevator_call_down_script'
@@ -37,7 +42,7 @@ entities:
         data: [0x0D, 0x01, 0x34, 0x01, 0x41, 0x10, 0x00, 0x00, 0x00, 0x03]
         mask: [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0xFF]
       state_text: >
-        data[9] >= 0xB0 ? 'B' + string(data[9] - 0xB0) : string(data[9])
+        data[9] >= 0xB0 ? 'B' + string(data[9] - 0xB0) : string(bcd_to_int(data[9]))
 
     - id: 'elevator_state_1'
       name: 'Elevator State 1'
@@ -57,7 +62,7 @@ entities:
         data: [0x0D, 0x01, 0x34, 0x01, 0x41, 0x10, 0x00, 0x00, 0x00, 0x04]
         mask: [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0xFF]
       state_text: >
-        data[9] >= 0xB0 ? 'B' + string(data[9] - 0xB0) : string(data[9])
+        data[9] >= 0xB0 ? 'B' + string(data[9] - 0xB0) : string(bcd_to_int(data[9]))
 
     - id: 'elevator_state_2'
       name: 'Elevator State 2'

--- a/gallery/list.json
+++ b/gallery/list.json
@@ -687,9 +687,9 @@
           "file": "hyundai_imazu/elevator2.yaml",
           "name": "현대통신 엘리베이터 2대",
           "name_en": "Hyundai Telecom Elevator x2",
-          "description": "현대통신 월패드용 엘리베이터 2대가 있는 경우 호출 및 상태 확인 설정입니다.",
-          "description_en": "Elevator call and status configuration for Hyundai Telecom wallpads.",
-          "version": "1.0.2",
+          "description": "현대통신 월패드용 엘리베이터 2대가 있는 경우 호출 및 상태 확인 설정입니다. 참고:https://yogyui.tistory.com/entry/%ED%98%84%EB%8C%80%ED%86%B5%EC%8B%A0-%EC%9B%94%ED%8C%A8%EB%93%9C-RS-485-%ED%86%B5%EC%8B%A0-%ED%94%84%EB%A1%9C%ED%86%A0%EC%BD%9C-%EC%97%98%EB%A6%AC%EB%B2%A0%EC%9D%B4%ED%84%B0-%ED%98%B8%EC%B6%9C",
+          "description_en": "Elevator call and status configuration for Hyundai Telecom wallpads. Reference: https://yogyui.tistory.com/entry/%ED%98%84%EB%8C%80%ED%86%B5%EC%8B%A0-%EC%9B%94%ED%8C%A8%EB%93%9C-RS-485-%ED%86%B5%EC%8B%A0-%ED%94%84%EB%A1%9C%ED%86%A0%EC%BD%9C-%EC%97%98%EB%A6%AC%EB%B2%A0%EC%9D%B4%ED%84%B0-%ED%98%B8%EC%B6%9C",
+          "version": "1.0.3",
           "author": "wooooooooooook",
           "tags": [
             "elevator",

--- a/gallery/list_new.json
+++ b/gallery/list_new.json
@@ -1955,9 +1955,9 @@
           "file": "hyundai_imazu/elevator2.yaml",
           "name": "현대통신 엘리베이터 2대",
           "name_en": "Hyundai Telecom Elevator x2",
-          "description": "현대통신 월패드용 엘리베이터 2대가 있는 경우 호출 및 상태 확인 설정입니다.",
-          "description_en": "Elevator call and status configuration for Hyundai Telecom wallpads.",
-          "version": "1.0.2",
+          "description": "현대통신 월패드용 엘리베이터 2대가 있는 경우 호출 및 상태 확인 설정입니다. 참고:https://yogyui.tistory.com/entry/%ED%98%84%EB%8C%80%ED%86%B5%EC%8B%A0-%EC%9B%94%ED%8C%A8%EB%93%9C-RS-485-%ED%86%B5%EC%8B%A0-%ED%94%84%EB%A1%9C%ED%86%A0%EC%BD%9C-%EC%97%98%EB%A6%AC%EB%B2%A0%EC%9D%B4%ED%84%B0-%ED%98%B8%EC%B6%9C",
+          "description_en": "Elevator call and status configuration for Hyundai Telecom wallpads. Reference: https://yogyui.tistory.com/entry/%ED%98%84%EB%8C%80%ED%86%B5%EC%8B%A0-%EC%9B%94%ED%8C%A8%EB%93%9C-RS-485-%ED%86%B5%EC%8B%A0-%ED%94%84%EB%A1%9C%ED%86%A0%EC%BD%9C-%EC%97%98%EB%A6%AC%EB%B2%A0%EC%9D%B4%ED%84%B0-%ED%98%B8%EC%B6%9C",
+          "version": "1.0.3",
           "author": "wooooooooooook",
           "tags": [
             "elevator",
@@ -1973,7 +1973,24 @@
             "automations": 0,
             "scripts": 2
           },
-          "discovery": null
+          "discovery": {
+            "match": {
+              "data": [
+                13,
+                1,
+                52,
+                1,
+                65
+              ],
+              "mask": [
+                0,
+                255,
+                255,
+                255,
+                255
+              ]
+            }
+          }
         },
         {
           "file": "hyundai_imazu/elevator_arrived_state.yaml",


### PR DESCRIPTION
### Motivation
- 현대 imazu 갤러리의 1대 엘리베이터 설정 기준을 2대 스니펫에 반영하여 동기화하고 정확도를 높이기 위함입니다.
- 스니펫 검색(디스커버리)과 층수 해석(BCD 변환) 누락으로 인한 자동 매칭/표시 오류를 방지하기 위함입니다.

### Description
- `gallery/hyundai_imazu/elevator2.yaml`의 `meta`에 참조 링크를 추가하고 `version`을 `1.0.3`으로 패치했습니다.
- 동일 파일에 `discovery.match` 블록을 추가하여 패킷 기반 자동 탐지를 지원하도록 했습니다.
- 엘리베이터 층수 표시 로직의 `state_text`를 BCD 처리를 위해 `string(bcd_to_int(data[9]))`로 변경하여 16진/BCD 혼용 처리를 개선했습니다.
- 갤러리 색인 파일인 `gallery/list.json` 및 `gallery/list_new.json`의 해당 항목을 서술(`description`/`description_en`), `version`, 및 `discovery` 메타데이터와 함께 동기화했습니다.

### Testing
- 빌드: `pnpm build`를 실행하여 패키지 빌드가 정상적으로 완료되었습니다.
- 린트: `pnpm lint`를 실행하여 타입/검사(`tsc`/`svelte-check`) 경고 및 오류 없이 완료되었습니다.
- 단위/통합: `pnpm test`로 Vitest 전체 스위트를 실행했고 자동화된 테스트가 통과하여 총 테스트가 성공(`333 tests passed`)했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69772cce8764832c84949b027872a487)