### PR TITLE
CEL에 `len(list|string)` 헬퍼 추가

### DIFF
--- a/docs/CEL_GUIDE.md
+++ b/docs/CEL_GUIDE.md
@@ -61,6 +61,7 @@ YAML 파일에서 `state_value`, `command_temperature` 등의 속성에 CEL 표�
 *   `bitNot(int)`: 비트 NOT 연산 (`~`)
 *   `bitShiftLeft(int, int)`: 비트 왼쪽 시프트 (`<<`)
 *   `bitShiftRight(int, int)`: 비트 오른쪽 시프트 (`>>`)
+*   `len(list|string)`: 리스트 또는 문자열 길이 반환
 *   `double(value)`: 값을 실수형(double)으로 변환 (나눗셈 등을 위해 사용)
 *   `has(expr)`: 선택적 필드 존재 여부 확인 (예: `get_from_state('value') != null`)
 *   `get_from_states(entity_id, attribute, default?)`: `states` 맵에서 엔티티/속성 값을 안전하게 조회 (없으면 `null`, 기본값을 넘기면 해당 값 반환)

--- a/packages/core/src/protocol/cel-executor.ts
+++ b/packages/core/src/protocol/cel-executor.ts
@@ -231,6 +231,12 @@ export class CelExecutor {
     this.env.registerFunction('bitNot(int): int', (a: bigint) => ~a);
     this.env.registerFunction('bitShiftLeft(int, int): int', (a: bigint, b: bigint) => a << b);
     this.env.registerFunction('bitShiftRight(int, int): int', (a: bigint, b: bigint) => a >> b);
+    this.env.registerFunction('len(list): int', (value: { length: number } | null) =>
+      BigInt(value?.length ?? 0),
+    );
+    this.env.registerFunction('len(string): int', (value: string | null) =>
+      BigInt(value?.length ?? 0),
+    );
     this.env.registerFunction(
       'get_from_states(string, string): dyn',
       (entityId: string, key: string) => this.getFromStates(entityId, key) ?? null,

--- a/packages/core/test/cel-executor.test.ts
+++ b/packages/core/test/cel-executor.test.ts
@@ -53,6 +53,11 @@ describe('CelExecutor', () => {
     expect(executor.execute('bitShiftLeft(1, 2)', {})).toBe(4);
   });
 
+  it('should handle len helper for list and string', () => {
+    expect(executor.execute('len(data)', { data: [1, 2, 3] })).toBe(3);
+    expect(executor.execute('len("abc")', {})).toBe(3);
+  });
+
   it('should handle state value calculation (Commax example)', () => {
     // double((bcd_to_int(data[4]) * 10000) + (bcd_to_int(data[5]) * 100) + bcd_to_int(data[6])) * 0.1
     // data: [..., ..., ..., ..., 0x12, 0x34, 0x56] -> 12345.6


### PR DESCRIPTION
### Motivation

- 갤러리의 표현식 예시(`int((len(data) - 7) / 2)`)가 CEL에서 `len` 함수 부재로 실패하여 이를 지원할 필요가 있었습니다.

### Description

- CEL 실행기(`packages/core/src/protocol/cel-executor.ts`)에 `len(list): int` 및 `len(string): int` 헬퍼를 등록했습니다.
- 헬퍼 동작을 검증하는 테스트를 `packages/core/test/cel-executor.test.ts`에 추가했습니다.
- 사용자 문서 `docs/CEL_GUIDE.md`에 `len` 헬퍼 설명을 보강했습니다.

### Testing

- 빌드: `pnpm build`를 실행하여 빌드가 성공했음을 확인했습니다.
- 린트: `pnpm lint`를 실행하여 문제 없이 통과했음을 확인했습니다.
- 테스트: `pnpm test`를 실행하여 전체 유닛 테스트가 성공적으로 통과함(자동화 테스트 통과)으로 확인했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69785bac2874832ca484cd2273f4b335)