### PR TITLE
hassio-addon: ARM v7에서 pnpm build 사용하도록 빌드 분기 추가

### DIFF
--- a/hassio-addon/Dockerfile
+++ b/hassio-addon/Dockerfile
@@ -28,9 +28,15 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
 # Copy source code
 COPY . .
 
-# Build packages using Turborepo with cache mount
+# Build packages (core, ui, service)
+ARG TARGETARCH
+ARG TARGETVARIANT
 RUN --mount=type=cache,target=/app/.turbo \
-    pnpm turbo build --filter=@rs485-homenet/service...
+    if [ "$TARGETARCH" = "arm" ] && [ "$TARGETVARIANT" = "v7" ]; then \
+      pnpm build; \
+    else \
+      pnpm turbo build --filter=@rs485-homenet/service...; \
+    fi
 
 
 


### PR DESCRIPTION
### Motivation
- ARM v7 환경에서 Turborepo 실행이 실패하여 addon 이미지 빌드가 실패하는 문제를 우회하기 위해 특정 아키텍처에서만 `pnpm build`를 사용하도록 분기합니다.

### Description
- `hassio-addon/Dockerfile`에 `ARG TARGETARCH` 및 `ARG TARGETVARIANT`를 추가하고 빌드 단계에서 조건문으로 `arm` + `v7`인 경우에만 `pnpm build`를 실행하도록 변경했습니다.
- 그 외 아키텍처는 기존대로 `pnpm turbo build --filter=@rs485-homenet/service...` 를 사용하도록 유지했습니다.
- 기존의 캐시 마운트(`.turbo`)와 의존성 설치/런타임 정리 로직은 그대로 보존했습니다.
- 관련 문서는 변경하지 않았으며, 이번 변경으로 문서 수정이 필요하지 않음을 확인했습니다.

### Testing
- `pnpm build`를 실행하여 빌드가 성공함을 확인했습니다 (성공).
- `pnpm lint`를 실행하여 타입 검사 및 Svelte 진단이 통과함을 확인했습니다 (성공).
- `pnpm test`를 실행하여 전체 테스트 스위트가 통과함을 확인했습니다 (성공).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697868fa2b18832c94b9169cd76a61a4)