### PR TITLE
optimize(docker): update hassio-addon-dev to use multi-stage build and turbo

### DIFF
--- a/hassio-addon-dev/Dockerfile
+++ b/hassio-addon-dev/Dockerfile
@@ -1,13 +1,10 @@
-# Stage 1: Builder
-# node:20-slim (Debian based) is used to avoid QEMU hangs during pnpm install/build on ARM64
-FROM node:20-slim AS builder
+# Stage 1: Common Builder (Host Architecture)
+# Builds UI and Service packages which are architecture independent
+FROM --platform=$BUILDPLATFORM node:20-slim AS common-builder
 
-# Set CI=true to prevent pnpm from requiring a TTY for commands like prune
 ENV CI=true
-
 WORKDIR /app
 
-# Install pnpm via corepack
 ARG NPM_REGISTRY=https://registry.npmjs.org
 RUN corepack enable \
   && npm config set registry "$NPM_REGISTRY" \
@@ -19,17 +16,53 @@ COPY packages/core/package.json packages/core/
 COPY packages/service/package.json packages/service/
 COPY packages/ui/package.json packages/ui/
 
-
-# Install dependencies
-RUN pnpm install --frozen-lockfile
+# Install dependencies (host arch)
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile --network-concurrency 1
 
 # Copy source code
 COPY . .
 
-# Build packages (core, ui, service)
-RUN pnpm build
+# Build everything (fast on host)
+# core is built here too to provide types for service, but will be rebuilt in target stage
+RUN --mount=type=cache,target=/app/.turbo \
+    pnpm turbo build --filter=@rs485-homenet/service...
 
 
+# Stage 2: Builder (Target Architecture)
+# Rebuilds Core with native dependencies for the target architecture
+FROM node:20-slim AS builder
+
+ENV CI=true
+WORKDIR /app
+
+ARG NPM_REGISTRY=https://registry.npmjs.org
+RUN corepack enable \
+  && npm config set registry "$NPM_REGISTRY" \
+  && corepack prepare pnpm@latest --activate
+
+# Copy workspace configuration
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY packages/core/package.json packages/core/
+COPY packages/service/package.json packages/service/
+COPY packages/ui/package.json packages/ui/
+
+# Install dependencies (target arch)
+# This compiles native modules like serialport for the target
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile --network-concurrency 1
+
+# Copy source code
+COPY . .
+
+# Copy pre-built artifacts from common-builder
+COPY --from=common-builder /app/packages/ui/dist ./packages/ui/dist
+COPY --from=common-builder /app/packages/service/dist ./packages/service/dist
+COPY --from=common-builder /app/packages/service/static ./packages/service/static
+
+# Build Core for Target Architecture
+# Use turbo build as requested (dev addon does not support armv7)
+RUN pnpm turbo build --filter=@rs485-homenet/core
 
 # Clean up source code and build artifacts not needed for runtime
 # 1. packages/ui: Already built and copied to service/static
@@ -45,7 +78,27 @@ RUN rm -rf packages/ui \
 # We use 'install --prod' instead of 'prune --prod' because the latter can incorrectly remove workspace dependencies
 RUN pnpm install --prod --frozen-lockfile
 
-# Stage 2: Runner
+# Final cleanup of node_modules to remove unnecessary files
+# Removes: maps, TS sources, docs, licenses, C/C++ sources/headers (after build), and build artifacts
+RUN find node_modules -type f \( \
+  -name "*.map" -o \
+  -name "*.ts" -o \
+  -name "*.md" -o \
+  -name "LICENSE" -o \
+  -name "README.md" -o \
+  -name "*.txt" -o \
+  -name "*.log" -o \
+  -name "*.tlog" -o \
+  -name "*.obj" -o \
+  -name "*.c" -o \
+  -name "*.h" -o \
+  -name "*.cpp" -o \
+  -name "*.html" -o \
+  -name "*.yml" -o \
+  -name "*.yaml" \
+  \) -delete
+
+# Stage 3: Runner
 # node:20-alpine is used for a smaller runtime image
 FROM node:20-alpine AS runner
 


### PR DESCRIPTION
Updated hassio-addon-dev/Dockerfile to use a multi-stage build strategy similar to hassio-addon. Enabled turbo for the core build step as ARMv7 support is not required for the dev addon. Preserved the use of hassio-addon/run.sh for timezone support.

---
*PR created automatically by Jules for task [15077129351487733991](https://jules.google.com/task/15077129351487733991) started by @wooooooooooook*