### PR TITLE
🧹 Housekeeper: Remove unused imports in core entities

### DIFF
--- a/.jules/housekeeper.md
+++ b/.jules/housekeeper.md
@@ -13,3 +13,7 @@
 ## 2025-05-23 - Simulator Excluded from Root Lint
 **Observation:** The root `pnpm lint` script explicitly excludes `packages/simulator` (`--filter '!@rs485-homenet/simulator'`).
 **Action:** Manually verified `packages/simulator` linting. It should be integrated back into the main lint workflow in the future.
+
+## 2025-05-23 - Use tsc to Find Unused Code
+**Observation:** Since `tsconfig.json` disables `noUnusedLocals`, many unused imports accumulate.
+**Action:** Run `pnpm exec tsc --noEmit --noUnusedLocals --noUnusedParameters` to uncover them. Note that `_decodeValue` in `command.generator.ts` is intentionally unused (deprecated but preserved).

--- a/packages/core/src/domain/entities/climate.entity.ts
+++ b/packages/core/src/domain/entities/climate.entity.ts
@@ -1,6 +1,6 @@
 // packages/core/src/domain/entities/climate.entity.ts
 
-import { EntityConfig, CommandSchema, CommandSchemaOrCEL } from './base.entity.js';
+import { EntityConfig, CommandSchemaOrCEL } from './base.entity.js';
 import { StateSchema, StateNumSchemaOrCEL } from '../../protocol/types.js';
 
 export interface ClimateEntity extends EntityConfig {

--- a/packages/core/src/domain/entities/fan.entity.ts
+++ b/packages/core/src/domain/entities/fan.entity.ts
@@ -1,6 +1,6 @@
 // packages/core/src/domain/entities/fan.entity.ts
 
-import { EntityConfig, CommandSchema, CommandSchemaOrCEL } from './base.entity.js';
+import { EntityConfig, CommandSchemaOrCEL } from './base.entity.js';
 import { StateSchema, StateNumSchemaOrCEL } from '../../protocol/types.js';
 
 export interface FanEntity extends EntityConfig {

--- a/packages/core/src/domain/entities/light.entity.ts
+++ b/packages/core/src/domain/entities/light.entity.ts
@@ -1,6 +1,6 @@
 // packages/core/src/domain/entities/light.entity.ts
 
-import { EntityConfig, CommandSchema, CommandSchemaOrCEL } from './base.entity.js';
+import { EntityConfig, CommandSchemaOrCEL } from './base.entity.js';
 import { StateSchema, StateNumSchemaOrCEL } from '../../protocol/types.js';
 
 export interface LightEntity extends EntityConfig {

--- a/packages/core/src/domain/entities/number.entity.ts
+++ b/packages/core/src/domain/entities/number.entity.ts
@@ -1,6 +1,6 @@
 // packages/core/src/domain/entities/number.entity.ts
 
-import { EntityConfig, CommandSchema, CommandSchemaOrCEL } from './base.entity.js';
+import { EntityConfig, CommandSchemaOrCEL } from './base.entity.js';
 import { StateSchema, StateNumSchemaOrCEL } from '../../protocol/types.js';
 
 export interface NumberEntity extends EntityConfig {

--- a/packages/core/src/domain/entities/sensor.entity.ts
+++ b/packages/core/src/domain/entities/sensor.entity.ts
@@ -1,6 +1,6 @@
 // packages/core/src/domain/entities/sensor.entity.ts
 
-import { EntityConfig, CommandSchema, CommandSchemaOrCEL } from './base.entity.js';
+import { EntityConfig, CommandSchemaOrCEL } from './base.entity.js';
 import { StateSchema, StateNumSchemaOrCEL } from '../../protocol/types.js';
 
 export interface SensorEntity extends EntityConfig {

--- a/packages/core/src/domain/entities/text.entity.ts
+++ b/packages/core/src/domain/entities/text.entity.ts
@@ -1,7 +1,7 @@
 // packages/core/src/domain/entities/text.entity.ts
 
-import { EntityConfig, CommandSchema, CommandSchemaOrCEL } from './base.entity.js';
-import { StateSchema, StateNumSchemaOrCEL, StateSchemaOrCEL } from '../../protocol/types.js';
+import { EntityConfig, CommandSchemaOrCEL } from './base.entity.js';
+import { StateSchema } from '../../protocol/types.js';
 
 export interface TextEntity extends EntityConfig {
   state?: StateSchema;

--- a/packages/core/src/domain/entities/valve.entity.ts
+++ b/packages/core/src/domain/entities/valve.entity.ts
@@ -1,6 +1,6 @@
 // packages/core/src/domain/entities/valve.entity.ts
 
-import { EntityConfig, CommandSchema, CommandSchemaOrCEL } from './base.entity.js';
+import { EntityConfig, CommandSchemaOrCEL } from './base.entity.js';
 import { StateSchema, StateNumSchemaOrCEL } from '../../protocol/types.js';
 
 export interface ValveEntity extends EntityConfig {


### PR DESCRIPTION
🧹 Cleanup: Removed unused `CommandSchema` and other unused imports in `packages/core/src/domain/entities/*.entity.ts`.
✨ Benefit: Reduces noise and brings the code closer to enabling strict linting rules (`noUnusedLocals`).
🛡️ Verification: Ran `tsc --noEmit --noUnusedLocals` (verified only intended/ignored issues remain), `pnpm lint`, `pnpm build`, and `pnpm test` in `packages/core`.

---
*PR created automatically by Jules for task [9930905855135575638](https://jules.google.com/task/9930905855135575638) started by @wooooooooooook*