### PR TITLE
⚡ Bolt: Zero-allocation 2-byte checksum verification

### DIFF
--- a/packages/core/src/protocol/packet-parser.ts
+++ b/packages/core/src/protocol/packet-parser.ts
@@ -2,6 +2,7 @@ import { PacketDefaults, ChecksumType, Checksum2Type } from './types.js';
 import {
   calculateChecksumFromBuffer,
   calculateChecksum2FromBuffer,
+  verifyChecksum2FromBuffer,
   getChecksumFunction,
   getChecksumOffsetType,
   ByteArray,
@@ -1050,15 +1051,14 @@ export class PacketParser {
         const checksumOrScript = this.defaults.rx_checksum2 as string;
 
         if (this.checksum2Types.has(checksumOrScript)) {
-          const calculated = calculateChecksum2FromBuffer(
+          return verifyChecksum2FromBuffer(
             buffer,
             checksumOrScript as Checksum2Type,
             headerLength,
             checksumStart - offset,
             offset,
-          );
-          return (
-            calculated[0] === buffer[checksumStart] && calculated[1] === buffer[checksumStart + 1]
+            buffer[checksumStart],
+            buffer[checksumStart + 1],
           );
         } else if (this.preparedChecksum2) {
           // Prepared CEL Expression for 2-byte checksum


### PR DESCRIPTION
💡 **What**: Introduced `verifyChecksum2FromBuffer` in `packages/core/src/protocol/utils/checksum.ts` and updated `PacketParser` to use it.
🎯 **Why**: To reduce memory allocations in the packet parsing loop, specifically when verifying 2-byte checksums in Strategy A (Fixed Length with sparse headers) and other potential paths.
📊 **Impact**: Eliminates `[number, number]` array allocation for every candidate packet verification.
🔬 **Measurement**: Verified with `checksum2.test.ts`. Existing tests passed.

---
*PR created automatically by Jules for task [4367959492633843929](https://jules.google.com/task/4367959492633843929) started by @wooooooooooook*