### PR TITLE
🧹 Housekeeper: Enable global linting

### DIFF
--- a/.jules/housekeeper.md
+++ b/.jules/housekeeper.md
@@ -17,3 +17,7 @@
 ## 2025-05-23 - Use tsc to Find Unused Code
 **Observation:** Since `tsconfig.json` disables `noUnusedLocals`, many unused imports accumulate.
 **Action:** Run `pnpm exec tsc --noEmit --noUnusedLocals --noUnusedParameters` to uncover them. Note that `_decodeValue` in `command.generator.ts` is intentionally unused (deprecated but preserved).
+
+## 2025-05-23 - Global Linting Enabled
+**Observation:** The `lint` script in `package.json` was restricted to `service` and its dependencies, excluding `simulator` and `ui`.
+**Action:** Updated `package.json` to use `turbo lint` without filters, ensuring all packages are linted in the standard workflow. This resolves the previous observation "Simulator Excluded from Root Lint".

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dev:frontend": "pnpm --filter @rs485-homenet/ui dev",
     "schema:build": "pnpm --filter @rs485-homenet/core schema:generate",
     "simulate": "node packages/simulator/scripts/convert_trace.js",
-    "lint": "turbo lint --filter=@rs485-homenet/service...",
+    "lint": "turbo lint",
     "build": "turbo build --filter=@rs485-homenet/service...",
     "build:simulator": "pnpm --filter @rs485-homenet/simulator build",
     "format": "pnpm -r --if-present format",


### PR DESCRIPTION
🧹 Cleanup: Removed filter from `lint` script in `package.json` to include all workspaces (`core`, `service`, `ui`, `simulator`).
✨ Benefit: Ensures `packages/simulator` and `packages/ui` are linted in the standard workflow, addressing a gap noted in the housekeeper journal and improving code hygiene.
🛡️ Verification: Ran `pnpm lint` and confirmed all 4 packages are checked and pass.

---
*PR created automatically by Jules for task [12872553854007907037](https://jules.google.com/task/12872553854007907037) started by @wooooooooooook*