### PR TITLE
엔티티 상세에 preset_mode 명령용 `select`/`text` 입력 지원 추가

### DIFF
--- a/packages/service/src/routes/controls.routes.ts
+++ b/packages/service/src/routes/controls.routes.ts
@@ -146,8 +146,16 @@ export function createControlsRoutes(ctx: ControlsRoutesContext): Router {
 
           // Select entity
           if (entityType === 'select' && key === 'command_option') {
-            cmdInfo.inputType = 'text';
-            cmdInfo.options = (entity.options as string[]) ?? [];
+            const options = (entity.options as string[]) ?? [];
+            cmdInfo.options = options;
+            cmdInfo.inputType = options.length > 0 ? 'select' : 'text';
+          }
+
+          // Fan preset mode command supports xstr input, optionally with preset modes
+          if (key === 'command_preset_mode') {
+            const options = (entity.preset_modes as string[]) ?? [];
+            cmdInfo.options = options;
+            cmdInfo.inputType = options.length > 0 ? 'select' : 'text';
           }
 
           // Text entity

--- a/packages/service/src/types/index.ts
+++ b/packages/service/src/types/index.ts
@@ -121,7 +121,7 @@ export interface CommandInfo {
   entityType: string;
   commandName: string;
   displayName: string;
-  inputType?: 'number' | 'text';
+  inputType?: 'number' | 'text' | 'select';
   min?: number;
   max?: number;
   step?: number;

--- a/packages/ui/src/lib/components/EntityDetail.svelte
+++ b/packages/ui/src/lib/components/EntityDetail.svelte
@@ -345,6 +345,10 @@
       entity.commands.forEach((cmd: CommandInfo) => {
         if (cmd.inputType === 'number') {
           commandInputs[`${cmd.entityId}_${cmd.commandName}`] = cmd.min ?? 0;
+        } else if (cmd.inputType === 'select') {
+          commandInputs[`${cmd.entityId}_${cmd.commandName}`] = cmd.options?.[0] ?? '';
+        } else if (cmd.inputType === 'text') {
+          commandInputs[`${cmd.entityId}_${cmd.commandName}`] = '';
         }
       });
     }
@@ -817,6 +821,53 @@
                           min={cmd.min}
                           max={cmd.max}
                           step={cmd.step}
+                          bind:value={commandInputs[`${cmd.entityId}_${cmd.commandName}`]}
+                        />
+                        <Button
+                          variant="primary"
+                          onclick={() =>
+                            handleExecute(cmd, commandInputs[`${cmd.entityId}_${cmd.commandName}`])}
+                          isLoading={executingCommands.has(`${cmd.entityId}-${cmd.commandName}`)}
+                          ariaLabel={$t('entity_detail.status.send_aria', {
+                            values: { command: cmd.displayName },
+                          })}
+                        >
+                          {$t('entity_detail.status.send')}
+                        </Button>
+                      </div>
+                    {:else if cmd.inputType === 'select'}
+                      <div class="input-group">
+                        <label for={`cmd-${cmd.entityId}-${cmd.commandName}`}
+                          >{cmd.commandName.replace('command_', '')}</label
+                        >
+                        <select
+                          id={`cmd-${cmd.entityId}-${cmd.commandName}`}
+                          bind:value={commandInputs[`${cmd.entityId}_${cmd.commandName}`]}
+                        >
+                          {#each cmd.options ?? [] as option}
+                            <option value={option}>{option}</option>
+                          {/each}
+                        </select>
+                        <Button
+                          variant="primary"
+                          onclick={() =>
+                            handleExecute(cmd, commandInputs[`${cmd.entityId}_${cmd.commandName}`])}
+                          isLoading={executingCommands.has(`${cmd.entityId}-${cmd.commandName}`)}
+                          ariaLabel={$t('entity_detail.status.send_aria', {
+                            values: { command: cmd.displayName },
+                          })}
+                        >
+                          {$t('entity_detail.status.send')}
+                        </Button>
+                      </div>
+                    {:else if cmd.inputType === 'text'}
+                      <div class="input-group">
+                        <label for={`cmd-${cmd.entityId}-${cmd.commandName}`}
+                          >{cmd.commandName.replace('command_', '')}</label
+                        >
+                        <input
+                          id={`cmd-${cmd.entityId}-${cmd.commandName}`}
+                          type="text"
                           bind:value={commandInputs[`${cmd.entityId}_${cmd.commandName}`]}
                         />
                         <Button
@@ -1379,7 +1430,22 @@
     font-size: 0.9rem;
   }
 
+  .input-group select {
+    background: #1e293b;
+    border: 1px solid #475569;
+    color: #fff;
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    min-width: 140px;
+    font-size: 0.9rem;
+  }
+
   .input-group input:focus {
+    outline: none;
+    border-color: #38bdf8;
+  }
+
+  .input-group select:focus {
     outline: none;
     border-color: #38bdf8;
   }

--- a/packages/ui/src/lib/types.ts
+++ b/packages/ui/src/lib/types.ts
@@ -144,7 +144,7 @@ export type CommandInfo = {
   entityType: string;
   commandName: string;
   displayName: string;
-  inputType?: 'number' | 'text';
+  inputType?: 'number' | 'text' | 'select';
   min?: number;
   max?: number;
   step?: number;


### PR DESCRIPTION
### Motivation
- `command_preset_mode` 처럼 사용자가 문자열(`xstr`)을 전달하는 명령은 텍스트 입력이 필요하거나 `preset_modes`가 있으면 선택형으로 제공되어야 합니다.
- UI에서 현재는 enum(선택형)과 숫자 입력만 제대로 렌더링되어 있어 `preset_mode` 같은 케이스에 적절한 입력 위젯이 필요했습니다.

### Description
- Controls API에서 `command_option` 및 `command_preset_mode`에 대해 옵션이 존재하면 `inputType: 'select'`를 내려주고 옵션이 없으면 `inputType: 'text'`로 처리하도록 `packages/service/src/routes/controls.routes.ts`를 수정했습니다.
- `CommandInfo` 타입에 `select` 입력 종류를 추가해 서비스/클라이언트 타입을 확장했습니다 (`packages/service/src/types/index.ts`, `packages/ui/src/lib/types.ts`).
- 엔티티 상세 모달의 명령 실행 UI에 `select`와 `text` 입력 렌더링을 추가하고 초기값 바인딩과 스타일을 보강했습니다 (`packages/ui/src/lib/components/EntityDetail.svelte`).

### Testing
- `pnpm build`를 실행해 전체 빌드가 성공함을 확인했습니다 (UI 정적 동기화 포함). — 성공.
- `pnpm lint`를 실행해 타입검사와 `svelte-check` 경고/오류가 없음을 확인했습니다. — 성공.
- `pnpm test`를 실행해 저장소의 Vitest 테스트 스위트가 통과함을 확인했습니다 (core/service/ui 패키지 테스트). — 성공.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979dc7e84d8832c9c9aabe2d1b2f382)