### PR TITLE
📜 Scribe: Update ChecksumType docs and definition

### DIFF
--- a/packages/core/src/protocol/types.ts
+++ b/packages/core/src/protocol/types.ts
@@ -5,8 +5,8 @@
  * - `add_no_header`: Sum of data bytes (excluding header) & 0xFF.
  * - `xor`: XOR of all bytes (header + data).
  * - `xor_no_header`: XOR of data bytes (excluding header).
- * - `samsung_rx`: Specialized Samsung Wallpad RX checksum (0xB0 ^ XOR).
- * - `samsung_tx`: Specialized Samsung Wallpad TX checksum.
+ * - `samsung_rx`: (@deprecated) Specialized Samsung Wallpad RX checksum (0xB0 ^ XOR). If data[0] < 0x7C, result ^= 0x80.
+ * - `samsung_tx`: (@deprecated) Specialized Samsung Wallpad TX checksum.
  * - `samsung_xor`: XOR of all bytes & 0x7F (Msb 0).
  * - `bestin_sum`: Cumulative XOR-based sum algorithm.
  * - `none`: No checksum calculation.
@@ -18,6 +18,8 @@ export type ChecksumType =
   | 'xor_no_header'
   | 'samsung_rx'
   | 'samsung_tx'
+  | 'samsung_xor'
+  | 'bestin_sum'
   | 'none';
 
 /**


### PR DESCRIPTION
💡 What: `packages/core/src/protocol/types.ts` 내의 `ChecksumType` 정의를 업데이트하여 `samsung_xor`와 `bestin_sum`을 포함시켰으며, `samsung_rx`와 `samsung_tx`에 `@deprecated` 태그를 추가했습니다.
🎯 Why: 코드 구현(`checksum.ts`)과 타입 정의 간의 불일치를 해결하고, `samsung_rx`의 조건부 로직에 대한 설명을 보강하기 위함입니다.
🧪 Verification: `pnpm lint`를 통과했으며, 스키마 생성 테스트를 수행했습니다.

---
*PR created automatically by Jules for task [14959782746407726369](https://jules.google.com/task/14959782746407726369) started by @wooooooooooook*