### PR TITLE
🎨 Palette: Localize loading state text in Button component

### DIFF
--- a/packages/ui/src/lib/components/Button.svelte
+++ b/packages/ui/src/lib/components/Button.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
+  import { t } from 'svelte-i18n';
 
   let {
     variant = 'primary',
@@ -57,7 +58,7 @@
 >
   {#if isLoading}
     <span class="spinner" aria-hidden="true"></span>
-    <span class="sr-only">Loading...</span>
+    <span class="sr-only">{$t('common.loading')}</span>
   {/if}
   <span class="content" class:hidden={isLoading} aria-hidden={isLoading || undefined}>
     {@render children?.()}


### PR DESCRIPTION
💡 **What:**
- Replaced hardcoded "Loading..." text in `packages/ui/src/lib/components/Button.svelte` with `{$t('common.loading')}`.
- Imported `t` from `svelte-i18n` in `Button.svelte`.

🎯 **Why:**
- To improve accessibility for non-English users (especially Korean users, as it's the primary fallback/target locale).
- The text is visually hidden (`sr-only`) but announced by screen readers. Localization ensures users hear the status in their preferred language.

📸 **Before/After:**
- **Before:** Screen reader announces "Loading..." (English) regardless of locale.
- **After:** Screen reader announces "로딩 중..." (Korean) when locale is Korean, or "Loading..." (English) otherwise.
- **Visual:** No visual change (spinner remains the same).

♿ **Accessibility:**
- Ensures the accessible name of the button reflects the loading state in the correct language when `isLoading` is true.
- Verified using Playwright that the button's accessible name changes correctly during loading.

---
*PR created automatically by Jules for task [15106363426589691830](https://jules.google.com/task/15106363426589691830) started by @wooooooooooook*