### PR TITLE
🧹 Housekeeper: Remove unused import in core

### DIFF
--- a/packages/core/src/protocol/packet-parser.ts
+++ b/packages/core/src/protocol/packet-parser.ts
@@ -1,7 +1,6 @@
 import { PacketDefaults, ChecksumType, Checksum2Type } from './types.js';
 import {
   calculateChecksumFromBuffer,
-  calculateChecksum2FromBuffer,
   verifyChecksum2FromBuffer,
   getChecksumFunction,
   getChecksumOffsetType,

--- a/packages/core/src/protocol/protocol-manager.ts
+++ b/packages/core/src/protocol/protocol-manager.ts
@@ -236,15 +236,15 @@ export class ProtocolManager extends EventEmitter {
       }
       if (stateUpdates) {
         matchedAny = true;
-        
+
         let targetDeviceId = device.getId();
         if (device.config.state_proxy && device.config.target_id) {
-            targetDeviceId = device.config.target_id;
-             if (isDebug) {
-                logger.debug(
-                  `[ProtocolManager] Proxying state from ${device.getId()} to ${targetDeviceId}`
-                );
-             }
+          targetDeviceId = device.config.target_id;
+          if (isDebug) {
+            logger.debug(
+              `[ProtocolManager] Proxying state from ${device.getId()} to ${targetDeviceId}`,
+            );
+          }
         }
 
         if (isDebug) {

--- a/packages/core/test/protocol/state_proxy.test.ts
+++ b/packages/core/test/protocol/state_proxy.test.ts
@@ -10,7 +10,7 @@ describe('State Proxy Logic', () => {
   it('should redirect state updates to target_id (Light)', () => {
     const protocolConfig: ProtocolConfig = {
       packet_defaults: {
-        rx_header: [0xAA],
+        rx_header: [0xaa],
         rx_checksum: 'none',
         rx_length: 2,
       },
@@ -43,7 +43,7 @@ describe('State Proxy Logic', () => {
 
     // Send packet for proxy
     // Header: 0xAA, Data: 0x02
-    manager.handleIncomingChunk(Buffer.from([0xAA, 0x02]));
+    manager.handleIncomingChunk(Buffer.from([0xaa, 0x02]));
 
     expect(stateSpy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -56,7 +56,7 @@ describe('State Proxy Logic', () => {
   it('should redirect complex attributes (Climate)', () => {
     const protocolConfig: ProtocolConfig = {
       packet_defaults: {
-        rx_header: [0xBB],
+        rx_header: [0xbb],
         rx_checksum: 'none',
         rx_length: 2,
       },
@@ -68,7 +68,7 @@ describe('State Proxy Logic', () => {
       name: 'Main Climate',
       type: 'climate',
       state: { data: [0x10] },
-      state_cool: { data: [0x10] }
+      state_cool: { data: [0x10] },
     };
     const targetDevice = new ClimateDevice(targetConfig, protocolConfig);
     manager.registerDevice(targetDevice);
@@ -94,13 +94,13 @@ describe('State Proxy Logic', () => {
 
     // Send packet for proxy
     // Header: 0xBB, Data: 0x20 (32 decimal)
-    manager.handleIncomingChunk(Buffer.from([0xBB, 0x20]));
+    manager.handleIncomingChunk(Buffer.from([0xbb, 0x20]));
 
     expect(stateSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         deviceId: 'main_climate',
         state: expect.objectContaining({
-            current_temperature: 32
+          current_temperature: 32,
         }),
       }),
     );


### PR DESCRIPTION
🧹 Cleanup: Removed unused `calculateChecksum2FromBuffer` import from `packages/core/src/protocol/packet-parser.ts`.
✨ Benefit: Reduces noise in strict type checking and improves code cleanliness.
🛡️ Verification: Ran `tsc --noUnusedLocals` and `pnpm test`. All 340 tests passed.

---
*PR created automatically by Jules for task [16248438101188209290](https://jules.google.com/task/16248438101188209290) started by @wooooooooooook*