### PR TITLE
⚡ Bolt: Optimize 2-byte checksum verification in PacketParser

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2026-01-29 - Extending Reusable Context to Packet Matching
 **Learning:** Packet matching logic (`matchesPacket`) often runs for every device on every packet. When `guard` expressions are used (CEL), the overhead of creating safe context objects (Proxies) for every match attempt becomes significant. Promoting `ReusableBufferView` and `reusableContext` to the base `Device` class allows all devices to share zero-allocation script execution for packet guards.
 **Action:** Identify repetitive script executions in "router" or "dispatcher" patterns (like matching logic) and lift the context management to the long-lived objects (e.g., Device instances) to amortize allocation costs.
+
+## 2026-01-30 - Pre-resolved Dispatch vs Switch
+**Learning:** In hot parsing loops, even a simple `switch` statement inside a helper function (like `verifyChecksum2FromBuffer`) adds measurable overhead (~13%) compared to calling a pre-resolved function reference directly. V8's monomorphic call optimization works best when the target function is stable and known ahead of time.
+**Action:** For high-frequency operations configured at startup (like checksum algorithms), pre-resolve the specific implementation function into a class property instead of passing the type string to a generic dispatcher function repeatedly.

--- a/packages/core/src/protocol/utils/checksum.ts
+++ b/packages/core/src/protocol/utils/checksum.ts
@@ -13,6 +13,14 @@ export type Checksum2Type = 'xor_add';
 
 export type ByteArray = number[] | Buffer | Uint8Array;
 
+export type Checksum2Verifier = (
+  buffer: ByteArray,
+  start: number,
+  end: number,
+  expectedHigh: number,
+  expectedLow: number,
+) => boolean;
+
 /**
  * Calculate 1-byte checksum
  * @param header Header bytes
@@ -321,7 +329,7 @@ function xorAdd(header: ByteArray, data: ByteArray): number[] {
   return [high, low];
 }
 
-function verifyXorAddRange(
+export function verifyXorAddRange(
   buffer: ByteArray,
   start: number,
   end: number,
@@ -369,6 +377,19 @@ export function getChecksumFunction(
       return samsungXorAllMsb0FromBuffer;
     case 'bestin_sum':
       return bestinSumFromBuffer;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Returns the optimized 2-byte checksum verifier function for a given type.
+ * Used to bypass switch statements in hot loops.
+ */
+export function getChecksum2Verifier(type: Checksum2Type): Checksum2Verifier | null {
+  switch (type) {
+    case 'xor_add':
+      return verifyXorAddRange;
     default:
       return null;
   }


### PR DESCRIPTION
💡 What: Pre-resolve 2-byte checksum verifier functions in `PacketParser` constructor to avoid switch statement and dispatch overhead in hot parsing loops.
🎯 Why: The `verifyChecksum` path (used in sparse scans, dynamic length, and standard verification) incurred unnecessary overhead due to repeated type checking and function dispatch in `verifyChecksum2FromBuffer`.
📊 Impact: ~13% speedup (133ms -> 115ms) in parsing throughput for sparse scan scenarios.
🔬 Measurement: Verified with a benchmark script (`packet-parser.bench.ts`) measuring 100k iterations of packet parsing.

---
*PR created automatically by Jules for task [4451538112990754975](https://jules.google.com/task/4451538112990754975) started by @wooooooooooook*