### PR TITLE
🧹 Housekeeper: Remove unused import in generic.device.ts

### DIFF
--- a/packages/core/src/protocol/devices/generic.device.ts
+++ b/packages/core/src/protocol/devices/generic.device.ts
@@ -2,7 +2,7 @@ import { Device } from '../device.js';
 import { DeviceConfig, ProtocolConfig } from '../types.js';
 import { StateSchema, StateNumSchema } from '../types.js';
 import { matchesPacket } from '../../utils/packet-matching.js';
-import { CelExecutor, CompiledScript, ReusableBufferView } from '../cel-executor.js';
+import { CelExecutor, CompiledScript } from '../cel-executor.js';
 import {
   calculateChecksum,
   calculateChecksum2,


### PR DESCRIPTION
🧹 Cleanup: Removed unused `ReusableBufferView` import in `packages/core/src/protocol/devices/generic.device.ts`.
✨ Benefit: Reduces noise in strict linting checks and cleans up the code.
🛡️ Verification: Ran `tsc --noEmit --noUnusedLocals` on core package (error gone), and ran root `pnpm lint` and `pnpm test` (all passed).

---
*PR created automatically by Jules for task [8803034893244436136](https://jules.google.com/task/8803034893244436136) started by @wooooooooooook*