### PR TITLE
feat(ui): add copy button to packet sender preview

### DIFF
--- a/packages/ui/src/lib/i18n/locales/en.json
+++ b/packages/ui/src/lib/i18n/locales/en.json
@@ -329,6 +329,7 @@
     "copied": "Copied!",
     "loading": "Loading...",
     "refresh": "Refresh",
+    "copy": "Copy",
     "status": {
       "idle": "Idle",
       "starting": "Starting",


### PR DESCRIPTION
This PR enhances the usability of the Packet Sender tool by adding a "Copy" button to the packet preview section. This allows users to easily copy the generated hex string for use in other tools or documentation.

Key changes:
- Added a copy button with an icon next to the preview code.
- Implemented a `copyToClipboard` utility function that supports both the modern Clipboard API and a `document.execCommand` fallback, ensuring functionality in non-secure contexts often found in local IoT deployments.
- Added visual feedback (icon change) when copying is successful.
- Added the missing "copy" translation key to `en.json` to resolve a localization gap.
- Verified with Playwright to ensure correct rendering and interaction.

---
*PR created automatically by Jules for task [1449084565163858844](https://jules.google.com/task/1449084565163858844) started by @wooooooooooook*