### PR TITLE
🧹 Housekeeper: Remove debug console.log in SystemTopology

### DIFF
--- a/packages/ui/src/lib/components/SystemTopology.svelte
+++ b/packages/ui/src/lib/components/SystemTopology.svelte
@@ -45,29 +45,6 @@
   const hasCoreWarning = $derived(!hasCoreError && isWarning(bridgeStatus));
   const hasMqttWarning = $derived(!hasMqttError && isWarning(mqttStatus));
 
-  // DEBUG: Log all error states for debugging
-  $effect(() => {
-    if (import.meta.env.DEV) {
-      console.log('[SystemTopology] Error States Debug:', {
-        bridgeStatus,
-        mqttStatus,
-        portMetadataStatus: portMetadata?.status,
-        globalError,
-        mqttError,
-        serialError,
-        portMetadataError: portMetadata?.error,
-        portMetadataErrorInfo: portMetadata?.errorInfo,
-        // Derived states
-        hasSerialError,
-        hasCoreError,
-        hasMqttError,
-        hasSerialWarning,
-        hasCoreWarning,
-        hasMqttWarning,
-      });
-    }
-  });
-
   function isGreen(status: string | undefined) {
     return status === 'connected' || status === 'started';
   }


### PR DESCRIPTION
- Removed debug `console.log` block from `packages/ui/src/lib/components/SystemTopology.svelte`.
- Ran `pnpm format` to ensure style consistency.
- Verified build and lint checks pass.

---
*PR created automatically by Jules for task [17862403898708147124](https://jules.google.com/task/17862403898708147124) started by @wooooooooooook*