### PR TITLE
Ezville 전열교환기 자동 모드의 state_on 체크 수정

### DIFF
--- a/gallery/ezville/fan1.yaml
+++ b/gallery/ezville/fan1.yaml
@@ -1,0 +1,63 @@
+meta:
+  name: "전열교환기 (자동 모드)"
+  name_en: "heat exchanger fan (auto mode)"
+  description: "Ezville 전열교환기 설정입니다. 자동 모드를 포함합니다."
+  description_en: "Ezville heat exchanger fan configuration with auto mode."
+  version: "1.0.0"
+  author: "loveangelsa"
+  tags: ["heat exchanger fan", "ezville", "auto mode"]
+
+discovery:
+  match:
+    data: [0x32, 0x01, 0x81]
+    mask: [0xFF, 0xFF, 0xFF]
+
+entities:
+  fan:
+    - id: heat_exchanger_fan
+      name: "전열교환기"
+
+      # 상태 패킷 식별
+      state:
+        data: [0x32, 0x01, 0x81]
+
+      # 전원 상태 감지 (7번째 바이트 기준)
+      state_on: >-
+        data[7] != 0x00
+      state_off:
+        offset: 7
+        data: [0x00]
+
+      # 전원 제어
+      command_on:
+        data: [0x32, 0x01, 0x42, 0x01, 0x01]  # 약풍으로 켜기
+      command_off:
+        data: [0x32, 0x01, 0x41, 0x01, 0x00]
+      command_update:
+        data: [0x32, 0x01, 0x01, 0x00]
+
+      # 프리셋 모드 정의
+      preset_modes: ["약", "중", "강", "자동"]
+
+      # 현재 속도 감지 (CEL 표현식)
+      state_preset_mode: >-
+        data[7] == 0x01 ? "약" :
+        (data[7] == 0x02 ? "중" :
+        (data[7] == 0x03 ? "강" :
+        (data[7] == 0x04 ? "자동" : "off")))
+
+      # 속도 제어 명령 (CEL 표현식)
+      command_preset_mode: >-
+        xstr == "약" ? [0x32, 0x01, 0x42, 0x01, 0x01] :
+        (xstr == "중" ? [0x32, 0x01, 0x42, 0x01, 0x02] :
+        (xstr == "강" ? [0x32, 0x01, 0x42, 0x01, 0x03] :
+        [0x32, 0x01, 0x43, 0x01, 0x04]))
+
+automation:
+  - id: 'update_fan_state'
+    trigger:
+      - type: schedule
+        every: 1m
+    then:
+      - action: command
+        target: id(heat_exchanger_fan).command_update()

--- a/gallery/list.json
+++ b/gallery/list.json
@@ -514,6 +514,28 @@
           }
         },
         {
+          "file": "ezville/fan1.yaml",
+          "name": "전열교환기 (자동 모드)",
+          "name_en": "heat exchanger fan (auto mode)",
+          "description": "Ezville 전열교환기 설정입니다. 자동 모드를 포함합니다.",
+          "description_en": "Ezville heat exchanger fan configuration with auto mode.",
+          "version": "1.0.0",
+          "author": "loveangelsa",
+          "tags": [
+            "heat exchanger fan",
+            "ezville",
+            "auto mode"
+          ],
+          "parameters": [],
+          "content_summary": {
+            "entities": {
+              "fan": 1
+            },
+            "automations": 1,
+            "scripts": 0
+          }
+        },
+        {
           "file": "ezville/gas_valve.yaml",
           "name": "가스밸브 설정",
           "name_en": "Gas Valve",

--- a/gallery/list_new.json
+++ b/gallery/list_new.json
@@ -1477,6 +1477,42 @@
           }
         },
         {
+          "file": "ezville/fan1.yaml",
+          "name": "전열교환기 (자동 모드)",
+          "name_en": "heat exchanger fan (auto mode)",
+          "description": "Ezville 전열교환기 설정입니다. 자동 모드를 포함합니다.",
+          "description_en": "Ezville heat exchanger fan configuration with auto mode.",
+          "version": "1.0.0",
+          "author": "loveangelsa",
+          "tags": [
+            "heat exchanger fan",
+            "ezville",
+            "auto mode"
+          ],
+          "parameters": [],
+          "content_summary": {
+            "entities": {
+              "fan": 1
+            },
+            "automations": 1,
+            "scripts": 0
+          },
+          "discovery": {
+            "match": {
+              "data": [
+                50,
+                1,
+                129
+              ],
+              "mask": [
+                255,
+                255,
+                255
+              ]
+            }
+          }
+        },
+        {
           "file": "ezville/gas_valve.yaml",
           "name": "가스밸브 설정",
           "name_en": "Gas Valve",


### PR DESCRIPTION
### Motivation
- 인라인 리뷰에서 `state_on`에 여러 값 리스트 문법이 지원되지 않는다고 지적되어 7번 바이트가 0이 아닐 때를 기준으로 ON 판정을 수행하도록 수정했습니다.

### Description
- `gallery/ezville/fan1.yaml`의 `state_on`을 리스트 방식에서 CEL 표현식 `data[7] != 0x00`으로 교체했습니다.
- 기존의 `state_off`(offset: 7, `data: [0x00]`)과 프리셋/명령 매핑은 변경 없이 유지했습니다.

### Testing
- `pnpm build`를 실행했으며 빌드가 성공했습니다.
- `pnpm lint`를 실행했으며 린트가 성공했습니다.
- `pnpm test`를 실행했으며 테스트 스위트가 모두 통과했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980354bf768832cbb79e3991081e1c7)