### PR TITLE
CVNet 난방 설정: 5번 이후 패킷(0x4B) 매핑 지원

### DIFF
--- a/gallery/cvnet/heaters_new.yaml
+++ b/gallery/cvnet/heaters_new.yaml
@@ -3,7 +3,7 @@ meta:
   name_en: "Heaters"
   description: "CVNet 난방 온도조절기 설정입니다. 개수를 지정할 수 있습니다."
   description_en: "CVNet heating thermostats. You can specify the number of thermostats."
-  version: "2.1.1"
+  version: "2.1.2"
   min_version: "1.16.0"
   author: "wooooooooooook"
   tags: ["climate", "heater", "thermostat", "cvnet"]
@@ -20,11 +20,11 @@ parameters:
 discovery:
   match:
     data: [0x20, 0x01, 0x4A]
-    mask: [0xFF, 0xFF, 0xFF]
+    mask: [0xFF, 0xFF, 0xFE]
   dimensions:
     - parameter: "heater_count"
       offset: 0
-      # CVNet 난방 패킷은 [0xF7, 0x20, 0x01, 0x4A, 0x81 ...] 형태이며 heater당 2바이트 데이터
+      # CVNet 난방 패킷은 [0xF7, 0x20, 0x01, 0x4A/0x4B, 0x81 ...] 형태이며 heater당 2바이트 데이터
       # Header(5)+Footer(1)+CS(1)? Overhead 7 bytes assumed per user request.
       # 공식: (전체길이 - 7) / 2
       transform: "int((len(data) - 7) / 2)"
@@ -42,17 +42,17 @@ entities:
         max_temperature: 30 °C
         temperature_step: 1 °C
       state:
-        data: [0x20, 0x01, 0x4A]
+        data: [0x20, 0x01, '{{i <= 4 ? 0x4A : 0x4B}}']
       state_temperature_current:
-        offset: '{{4 + i * 2}}'
+        offset: '{{4 + (i <= 4 ? i : i - 4) * 2}}'
       state_temperature_target: >-
-        bitAnd(data[{{3 + i * 2}}], 0x7F)
+        bitAnd(data[{{3 + (i <= 4 ? i : i - 4) * 2}}], 0x7F)
       state_off:
-        offset: '{{3 + i * 2}}'
+        offset: '{{3 + (i <= 4 ? i : i - 4) * 2}}'
         data: [0x00]
         mask: [0x80]
       state_heat:
-        offset: '{{3 + i * 2}}'
+        offset: '{{3 + (i <= 4 ? i : i - 4) * 2}}'
         data: [0x80]
         mask: [0x80]
       command_off: >-


### PR DESCRIPTION
### Motivation
- CVNet 난방 장비는 기본적으로 4개까지의 난방 방을 가정하지만 5번 방부터는 패킷 식별자가 0x4A에서 0x4B로 바뀌어 잘못된 인덱스로 매칭되는 문제가 보고되어 이를 해결하고자 합니다.

### Description
- `gallery/cvnet/heaters_new.yaml` 템플릿 버전을 `2.1.1`에서 `2.1.2`로 갱신했습니다.
- discovery 매칭 마스크를 `mask: [0xFF, 0xFF, 0xFE]`로 바꿔 `0x4A`와 `0x4B` 둘 다 허용하도록 수정했습니다.
- 각 난방 엔티티의 `state.data`를 `{{i <= 4 ? 0x4A : 0x4B}}` 조건식으로 변경해 5번 이후에는 `0x4B` 패킷을 사용하도록 했습니다.
- 온도/상태 바이트 오프셋 계산식을 `i <= 4 ? i : i - 4` 로 재매핑하여 5번 이후 방 인덱스를 올바르게 참조하도록 조정했습니다.

### Testing
- `pnpm build` 를 실행해 빌드가 성공함을 확인했습니다 (성공).
- `pnpm lint` 를 실행해 린트 검사가 통과됨을 확인했습니다 (성공).
- `pnpm test` 를 실행해 전체 테스트 스위트가 통과함을 확인했습니다 (성공).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980397d3ee0832caa839f1d99343329)