### PR TITLE
패킷 딕셔너리에 명령 패킷 정보 포함

### DIFF
--- a/packages/service/src/log-retention.service.ts
+++ b/packages/service/src/log-retention.service.ts
@@ -230,6 +230,16 @@ export class LogRetentionService {
   public getParsedPacketEntities(portId?: string): Record<string, string[]> {
     const result: Record<string, string[]> = {};
 
+    const formatCommandLabel = (log: CommandLogEntry): string => {
+      const base = `${log.entityId} (${log.command}`;
+      if (log.value === undefined) {
+        return `${base})`;
+      }
+      const valueLabel =
+        typeof log.value === 'string' ? log.value : JSON.stringify(log.value);
+      return `${base}: ${valueLabel})`;
+    };
+
     for (const log of this.parsedPacketLogs) {
       // Filter by portId if specified
       if (portId && log.portId !== portId) continue;
@@ -242,6 +252,21 @@ export class LogRetentionService {
       }
       if (!result[packetHex].includes(log.entityId)) {
         result[packetHex].push(log.entityId);
+      }
+    }
+
+    for (const log of this.commandPacketLogs) {
+      if (portId && log.portId !== portId) continue;
+
+      const packetHex = this.packetDictionaryReverse.get(log.packetId);
+      if (!packetHex) continue;
+
+      if (!result[packetHex]) {
+        result[packetHex] = [];
+      }
+      const label = formatCommandLabel(log);
+      if (!result[packetHex].includes(label)) {
+        result[packetHex].push(label);
       }
     }
 


### PR DESCRIPTION
### Motivation
- 패킷딕셔너리에서 명령 패킷이 ‘매칭됨’으로 표시되더라도 상태패킷처럼 어떤 엔티티/명령인지 보이지 않아 사용성 개선이 필요했습니다.

### Description
- `LogRetentionService.getParsedPacketEntities`에 명령 로그(`commandPacketLogs`)를 포함하도록 확장해 패킷 hex -> 엔티티 목록 매핑에 명령 라벨을 추가했습니다.
- 명령 라벨은 `entityId`, `command` 및 `value`(존재하는 경우)를 포함하는 문자열로 포맷하도록 `formatCommandLabel`을 추가했습니다.
- 관련 변경 파일: `packages/service/src/log-retention.service.ts`에서 `getParsedPacketEntities` 구현을 수정했습니다.

### Testing
- 빌드: `pnpm build`를 실행했고 성공했습니다.
- 린트: `pnpm lint`를 실행했고 성공했습니다.
- 테스트: `pnpm test`를 실행했고 전체 테스트가 통과했습니다 (core/service/ui/simulator 패키지 포함).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69803c7d0338832c8254f8fef78e6e17)