### PR TITLE
Add search functionality to Packet Dictionary

### DIFF
--- a/packages/ui/src/lib/components/PacketDictionaryView.svelte
+++ b/packages/ui/src/lib/components/PacketDictionaryView.svelte
@@ -11,6 +11,7 @@
   let error = $state<string | null>(null);
   let viewMode = $state<'parsed' | 'unmatched' | 'all'>('all');
   let sortDesc = $state(false);
+  let searchTerm = $state('');
 
   async function fetchData() {
     loading = true;
@@ -59,6 +60,16 @@
     } else {
       // 'all' mode - combine and deduplicate
       packets = Array.from(new Set([...parsedPackets, ...unmatchedPackets]));
+    }
+
+    if (searchTerm) {
+      const term = searchTerm.toLowerCase();
+      const hexTerm = term.replace(/\s+/g, '');
+      packets = packets.filter((packet) => {
+        if (packet.toLowerCase().replace(/\s+/g, '').includes(hexTerm)) return true;
+        const entities = data?.parsedPacketEntities[packet.toLowerCase()] || [];
+        return entities.some((e) => e.toLowerCase().includes(term));
+      });
     }
 
     packets.sort((a, b) => {
@@ -176,6 +187,12 @@
   {/if}
 
   <div class="controls">
+    <input
+      type="text"
+      class="search-input"
+      placeholder={$t('analysis.packet_dictionary.search_placeholder')}
+      bind:value={searchTerm}
+    />
     <div class="view-tabs">
       <Button
         variant={viewMode === 'all' ? 'primary' : 'secondary'}
@@ -501,5 +518,22 @@
 
   .error {
     color: var(--danger-color);
+  }
+
+  .search-input {
+    background: rgba(15, 23, 42, 0.5);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    color: #e2e8f0;
+    padding: 0.6rem 0.75rem;
+    border-radius: 8px;
+    width: 100%;
+    font-size: 0.9rem;
+    box-sizing: border-box;
+  }
+
+  .search-input:focus {
+    outline: none;
+    border-color: rgba(59, 130, 246, 0.5);
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
   }
 </style>

--- a/packages/ui/src/lib/i18n/locales/en.json
+++ b/packages/ui/src/lib/i18n/locales/en.json
@@ -300,7 +300,8 @@
       "tab_unmatched": "Unmatched",
       "empty": "No packets collected yet.",
       "sort_asc": "Sort A-Z",
-      "sort_desc": "Sort Z-A"
+      "sort_desc": "Sort Z-A",
+      "search_placeholder": "Search packet hex or entity name"
     },
     "stats": {
       "title": "Packet Interval Analysis",

--- a/packages/ui/src/lib/i18n/locales/ko.json
+++ b/packages/ui/src/lib/i18n/locales/ko.json
@@ -300,7 +300,8 @@
       "tab_unmatched": "미매칭",
       "empty": "아직 수집된 패킷이 없습니다.",
       "sort_asc": "오름차순 정렬",
-      "sort_desc": "내림차순 정렬"
+      "sort_desc": "내림차순 정렬",
+      "search_placeholder": "패킷 HEX 또는 엔티티 이름 검색"
     },
     "stats": {
       "title": "패킷 간격 분석",


### PR DESCRIPTION
Added a search input to the Packet Dictionary view.
Allows users to filter packets by hex string or matched entity name.
Updated `PacketDictionaryView.svelte` to include the search state and filtering logic.
Added translation keys for the search placeholder in `en.json` and `ko.json`.
Verified the functionality using Playwright tests.

---
*PR created automatically by Jules for task [11379888695411259485](https://jules.google.com/task/11379888695411259485) started by @wooooooooooook*