### PR TITLE
Refactor UI clipboard logic into a shared utility

### DIFF
--- a/packages/ui/src/lib/components/EntityDetail.svelte
+++ b/packages/ui/src/lib/components/EntityDetail.svelte
@@ -10,6 +10,7 @@
   import ActivityLogList from './ActivityLogList.svelte';
   import { triggerSystemRestart as restartApp } from '../utils/appControl';
   import { formatTime } from '../utils/time';
+  import { copyToClipboard } from '../utils/clipboard';
   import type {
     UnifiedEntity,
     CommandInfo,
@@ -676,12 +677,12 @@
   }
 
   async function handleCopyId() {
-    try {
-      await navigator.clipboard.writeText(entity.id);
+    const success = await copyToClipboard(entity.id);
+    if (success) {
       idCopied = true;
       setTimeout(() => (idCopied = false), 2000);
-    } catch (err) {
-      console.error('Failed to copy ID', err);
+    } else {
+      console.error('Failed to copy ID');
     }
   }
 
@@ -715,33 +716,6 @@
 
   let copiedPacket = $state<string | null>(null);
   let copyTimeout: ReturnType<typeof setTimeout>;
-
-  async function copyToClipboard(text: string): Promise<boolean> {
-    try {
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        await navigator.clipboard.writeText(text);
-        return true;
-      }
-      throw new Error('Clipboard API unavailable');
-    } catch (err) {
-      try {
-        const textArea = document.createElement('textarea');
-        textArea.value = text;
-        textArea.style.top = '0';
-        textArea.style.left = '0';
-        textArea.style.position = 'fixed';
-        document.body.appendChild(textArea);
-        textArea.focus();
-        textArea.select();
-        const successful = document.execCommand('copy');
-        document.body.removeChild(textArea);
-        return successful;
-      } catch (fallbackErr) {
-        console.error('Failed to copy', err, fallbackErr);
-        return false;
-      }
-    }
-  }
 
   async function copyPacket(packet: string) {
     const success = await copyToClipboard(packet);

--- a/packages/ui/src/lib/components/PacketDictionaryView.svelte
+++ b/packages/ui/src/lib/components/PacketDictionaryView.svelte
@@ -3,6 +3,7 @@
   import type { PacketDictionaryFullResponse } from '../types';
   import { fade } from 'svelte/transition';
   import Button from './Button.svelte';
+  import { copyToClipboard } from '../utils/clipboard';
 
   let { portId = null }: { portId?: string | null } = $props();
 
@@ -84,33 +85,6 @@
 
   let copiedPacket = $state<string | null>(null);
   let copyTimeout: ReturnType<typeof setTimeout>;
-
-  async function copyToClipboard(text: string): Promise<boolean> {
-    try {
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        await navigator.clipboard.writeText(text);
-        return true;
-      }
-      throw new Error('Clipboard API unavailable');
-    } catch (err) {
-      try {
-        const textArea = document.createElement('textarea');
-        textArea.value = text;
-        textArea.style.top = '0';
-        textArea.style.left = '0';
-        textArea.style.position = 'fixed';
-        document.body.appendChild(textArea);
-        textArea.focus();
-        textArea.select();
-        const successful = document.execCommand('copy');
-        document.body.removeChild(textArea);
-        return successful;
-      } catch (fallbackErr) {
-        console.error('Failed to copy', err, fallbackErr);
-        return false;
-      }
-    }
-  }
 
   async function copyPacket(packet: string) {
     const success = await copyToClipboard(packet);

--- a/packages/ui/src/lib/components/PacketLog.svelte
+++ b/packages/ui/src/lib/components/PacketLog.svelte
@@ -5,6 +5,7 @@
   import { formatTime } from '../utils/time';
   import { fade } from 'svelte/transition';
   import Button from './Button.svelte';
+  import { copyToClipboard } from '../utils/clipboard';
 
   let {
     parsedLogs = [],
@@ -153,33 +154,6 @@
 
   let copiedPacket = $state<string | null>(null);
   let copyTimeout: ReturnType<typeof setTimeout>;
-
-  async function copyToClipboard(text: string): Promise<boolean> {
-    try {
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        await navigator.clipboard.writeText(text);
-        return true;
-      }
-      throw new Error('Clipboard API unavailable');
-    } catch (err) {
-      try {
-        const textArea = document.createElement('textarea');
-        textArea.value = text;
-        textArea.style.top = '0';
-        textArea.style.left = '0';
-        textArea.style.position = 'fixed';
-        document.body.appendChild(textArea);
-        textArea.focus();
-        textArea.select();
-        const successful = document.execCommand('copy');
-        document.body.removeChild(textArea);
-        return successful;
-      } catch (fallbackErr) {
-        console.error('Failed to copy', err, fallbackErr);
-        return false;
-      }
-    }
-  }
 
   async function copyPacket(packet: string) {
     const success = await copyToClipboard(packet);

--- a/packages/ui/src/lib/components/PacketSender.svelte
+++ b/packages/ui/src/lib/components/PacketSender.svelte
@@ -2,6 +2,7 @@
   import { t } from 'svelte-i18n';
   import { fade } from 'svelte/transition';
   import Button from './Button.svelte';
+  import { copyToClipboard } from '../utils/clipboard';
 
   let { portId }: { portId: string } = $props();
 
@@ -61,36 +62,6 @@
     const timer = setTimeout(updatePreview, 300);
     return () => clearTimeout(timer);
   });
-
-  async function copyToClipboard(text: string): Promise<boolean> {
-    try {
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        await navigator.clipboard.writeText(text);
-        return true;
-      }
-      throw new Error('Clipboard API unavailable');
-    } catch (err) {
-      let textArea: HTMLTextAreaElement | null = null;
-      try {
-        textArea = document.createElement('textarea');
-        textArea.value = text;
-        textArea.style.top = '0';
-        textArea.style.left = '0';
-        textArea.style.position = 'fixed';
-        document.body.appendChild(textArea);
-        textArea.focus();
-        textArea.select();
-        return document.execCommand('copy');
-      } catch (fallbackErr) {
-        console.error('Failed to copy', err, fallbackErr);
-        return false;
-      } finally {
-        if (textArea && textArea.parentNode) {
-          document.body.removeChild(textArea);
-        }
-      }
-    }
-  }
 
   async function handleCopyPreview(text: string) {
     const success = await copyToClipboard(text);

--- a/packages/ui/src/lib/components/RawPacketLog.svelte
+++ b/packages/ui/src/lib/components/RawPacketLog.svelte
@@ -6,6 +6,7 @@
   import Dialog from './Dialog.svelte';
   import VirtualList from '@humanspeak/svelte-virtual-list';
   import { formatTime } from '../utils/time';
+  import { copyToClipboard } from '../utils/clipboard';
 
   let {
     rawPackets = [],
@@ -404,36 +405,6 @@
       setTimeout(() => {
         downloadError = $t('analysis.raw_log.ha_app_download_warning');
       }, 500);
-    }
-  }
-
-  async function copyToClipboard(text: string): Promise<boolean> {
-    try {
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        await navigator.clipboard.writeText(text);
-        return true;
-      }
-      throw new Error('Clipboard API unavailable');
-    } catch (err) {
-      let textArea: HTMLTextAreaElement | null = null;
-      try {
-        textArea = document.createElement('textarea');
-        textArea.value = text;
-        textArea.style.top = '0';
-        textArea.style.left = '0';
-        textArea.style.position = 'fixed';
-        document.body.appendChild(textArea);
-        textArea.focus();
-        textArea.select();
-        return document.execCommand('copy');
-      } catch (fallbackErr) {
-        console.error('Failed to copy', err, fallbackErr);
-        return false;
-      } finally {
-        if (textArea && textArea.parentNode) {
-          document.body.removeChild(textArea);
-        }
-      }
     }
   }
 

--- a/packages/ui/src/lib/utils/clipboard.ts
+++ b/packages/ui/src/lib/utils/clipboard.ts
@@ -1,0 +1,29 @@
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+    throw new Error('Clipboard API unavailable');
+  } catch (err) {
+    let textArea: HTMLTextAreaElement | null = null;
+    try {
+      textArea = document.createElement('textarea');
+      textArea.value = text;
+      textArea.style.top = '0';
+      textArea.style.left = '0';
+      textArea.style.position = 'fixed';
+      document.body.appendChild(textArea);
+      textArea.focus();
+      textArea.select();
+      return document.execCommand('copy');
+    } catch (fallbackErr) {
+      console.error('Failed to copy', err, fallbackErr);
+      return false;
+    } finally {
+      if (textArea && textArea.parentNode) {
+        document.body.removeChild(textArea);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR refactors the duplicated 'copy to clipboard' logic found in multiple UI components into a single, shared utility function `copyToClipboard` in `packages/ui/src/lib/utils/clipboard.ts`. This ensures consistent behavior, including a robust fallback mechanism for environments where the Clipboard API might be unavailable, and improves code maintainability.

---
*PR created automatically by Jules for task [15999480965126995811](https://jules.google.com/task/15999480965126995811) started by @wooooooooooook*