### PR TITLE
🎨 Palette: Dynamic accessibility labels for copy buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - [Empty State Controls]
 **Learning:** Hiding control buttons (like "Start Recording") when a list is empty prevents users from initiating actions to populate that list, creating a dead end.
 **Action:** Always ensure primary action buttons are visible regardless of data state. Use disabled states if an action is invalid, but keep the button visible if it's the entry point for the feature.
+
+## 2024-05-25 - [Dynamic Accessible Labels]
+**Learning:** Icon-only buttons that change state (like "Copy" -> "Copied") must update their `aria-label` and `title` to reflect the new state, otherwise screen reader users won't know the action succeeded.
+**Action:** Always bind `aria-label` and `title` to the state variable (e.g., `isCopied ? 'Copied' : 'Copy'`) for stateful icon buttons.

--- a/packages/ui/src/lib/components/EntityDetail.svelte
+++ b/packages/ui/src/lib/components/EntityDetail.svelte
@@ -1132,8 +1132,12 @@
                           <button
                             class="copy-btn"
                             onclick={() => copyPacket(packet.packet.toUpperCase())}
-                            aria-label={$t('common.copy')}
-                            title={$t('common.copy')}
+                            aria-label={copiedPacket === packet.packet.toUpperCase()
+                              ? $t('common.copied')
+                              : $t('common.copy')}
+                            title={copiedPacket === packet.packet.toUpperCase()
+                              ? $t('common.copied')
+                              : $t('common.copy')}
                           >
                             {#if copiedPacket === packet.packet.toUpperCase()}
                               <svg

--- a/packages/ui/src/lib/components/PacketDictionaryView.svelte
+++ b/packages/ui/src/lib/components/PacketDictionaryView.svelte
@@ -255,8 +255,8 @@
                 <button
                   class="copy-btn"
                   onclick={() => copyPacket(packet)}
-                  aria-label={$t('common.copy')}
-                  title={$t('common.copy')}
+                  aria-label={copiedPacket === packet ? $t('common.copied') : $t('common.copy')}
+                  title={copiedPacket === packet ? $t('common.copied') : $t('common.copy')}
                 >
                   {#if copiedPacket === packet}
                     <svg

--- a/packages/ui/src/lib/components/PacketLog.svelte
+++ b/packages/ui/src/lib/components/PacketLog.svelte
@@ -217,8 +217,12 @@
           <button
             class="copy-btn"
             onclick={() => copyPacket(getPayloadText(packet.data.packetId))}
-            aria-label={$t('common.copy')}
-            title={$t('common.copy')}
+            aria-label={copiedPacket === getPayloadText(packet.data.packetId)
+              ? $t('common.copied')
+              : $t('common.copy')}
+            title={copiedPacket === getPayloadText(packet.data.packetId)
+              ? $t('common.copied')
+              : $t('common.copy')}
           >
             {#if copiedPacket === getPayloadText(packet.data.packetId)}
               <svg

--- a/packages/ui/src/lib/components/PacketSender.svelte
+++ b/packages/ui/src/lib/components/PacketSender.svelte
@@ -220,8 +220,8 @@
           <button
             class="copy-btn"
             onclick={() => handleCopyPreview(toHexPairs(senderPreview!).join(' '))}
-            aria-label={$t('common.copy')}
-            title={$t('common.copy')}
+            aria-label={previewCopied ? $t('common.copied') : $t('common.copy')}
+            title={previewCopied ? $t('common.copied') : $t('common.copy')}
           >
             {#if previewCopied}
               <svg


### PR DESCRIPTION
Updated 'Copy' buttons in PacketSender, PacketDictionaryView, PacketLog, and EntityDetail to dynamically update their 'aria-label' and 'title' to 'Copied!' upon successful action. This provides essential feedback to screen reader users.

💡 What: Updated aria-label and title on copy buttons.
🎯 Why: Screen reader users received no feedback when the copy action succeeded, despite the visual icon change.
📸 Before/After: Visual icon change remains (copy -> checkmark), but now accessible name also changes ("Copy" -> "Copied!").
♿ Accessibility: Ensures WCAG 4.1.2 (Name, Role, Value) compliance for dynamic state changes.


---
*PR created automatically by Jules for task [1324646523026184414](https://jules.google.com/task/1324646523026184414) started by @wooooooooooook*