### PR TITLE
Add port_id alias for serial configuration

### DIFF
--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -13,6 +13,10 @@ async function loadYamlConfig(filePath: string): Promise<any> {
 function normalizeSerialConfig(serial: SerialConfig): SerialConfig {
   const normalized = { ...serial };
 
+  if (normalized.port_id && !normalized.portId) {
+    normalized.portId = normalized.port_id;
+  }
+
   if (normalized.portId) {
     normalized.portId = normalized.portId.toString().trim();
   } else {

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -329,6 +329,8 @@ export interface ScriptConfig {
 export interface SerialConfig {
   /** Identifier for this port (e.g. 'default', 'living_room'). */
   portId: string;
+  /** Alias for portId. */
+  port_id?: string;
   /** Device path (e.g. '/dev/ttyUSB0' or 'socket://IP:PORT'). */
   path: string;
   baud_rate: number;


### PR DESCRIPTION
Added `port_id` to `SerialConfig` interface and updated `normalizeSerialConfig` to handle the alias. Added a regression test (which was run and then deleted) to verify the behavior. Confirmed existing tests pass.

---
*PR created automatically by Jules for task [13003907323376286886](https://jules.google.com/task/13003907323376286886) started by @wooooooooooook*