### PR TITLE
chore(service): fix implicit any types and type mismatches in routes

### DIFF
--- a/packages/core/src/mqtt/discovery-manager.ts
+++ b/packages/core/src/mqtt/discovery-manager.ts
@@ -601,7 +601,7 @@ export class DiscoveryManager {
           payload.modes = availableModes;
           payload.mode_command_topic = `${this.mqttTopicPrefix}/${id}/mode/set`;
           payload.mode_state_topic = `${this.mqttTopicPrefix}/${id}/state`;
-          payload.mode_state_template = "{{ value_json.mode }}";
+          payload.mode_state_template = '{{ value_json.mode }}';
         }
 
         const fanModes = new Set<string>();

--- a/packages/service/src/log-retention.service.ts
+++ b/packages/service/src/log-retention.service.ts
@@ -235,8 +235,7 @@ export class LogRetentionService {
       if (log.value === undefined) {
         return `${base})`;
       }
-      const valueLabel =
-        typeof log.value === 'string' ? log.value : JSON.stringify(log.value);
+      const valueLabel = typeof log.value === 'string' ? log.value : JSON.stringify(log.value);
       return `${base}: ${valueLabel})`;
     };
 

--- a/packages/service/src/routes/config.routes.ts
+++ b/packages/service/src/routes/config.routes.ts
@@ -379,7 +379,7 @@ export function createConfigRoutes(ctx: ConfigRoutesContext): Router {
 
       for (const key of Object.keys(newItems)) {
         // Check if this key is one of the allowed entity types or automation/script
-        const configKey = key as keyof HomenetBridgeConfig;
+        const configKey = key as keyof HomenetBridgeConfig & string;
         if (
           !ENTITY_TYPE_KEYS.includes(configKey) &&
           configKey !== 'automation' &&
@@ -427,7 +427,7 @@ export function createConfigRoutes(ctx: ConfigRoutesContext): Router {
                 if (Array.isArray(otherList) && otherList.some((e: any) => e.id === newItem.id)) {
                   return res
                     .status(409)
-                    .json({ error: `ID '${newItem.id}' already exists in ${otherKey}.` });
+                    .json({ error: `ID '${newItem.id}' already exists in ${String(otherKey)}.` });
                 }
               }
             }

--- a/packages/service/src/routes/controls.routes.ts
+++ b/packages/service/src/routes/controls.routes.ts
@@ -341,7 +341,7 @@ export function createControlsRoutes(ctx: ControlsRoutesContext): Router {
     }
 
     const automations = currentConfigs.flatMap((config, index) =>
-      (config.automation || []).map((auto) => ({
+      (config.automation || []).map((auto: AutomationConfig) => ({
         ...auto,
         configFile: currentConfigFiles[index],
       })),
@@ -369,7 +369,7 @@ export function createControlsRoutes(ctx: ControlsRoutesContext): Router {
     const currentConfigFiles = ctx.getCurrentConfigFiles();
 
     const automation: AutomationConfig | undefined = currentConfigs[configIndex]?.automation?.find(
-      (item) => item.id === automationId,
+      (item: AutomationConfig) => item.id === automationId,
     );
     if (!automation) {
       return res.status(404).json({ error: 'Automation not found in loaded configs' });
@@ -489,7 +489,7 @@ export function createControlsRoutes(ctx: ControlsRoutesContext): Router {
     }
 
     const scripts = currentConfigs.flatMap((config, index) =>
-      (config.scripts || []).map((script) => ({
+      (config.scripts || []).map((script: ScriptConfig) => ({
         ...script,
         configFile: currentConfigFiles[index],
       })),
@@ -517,7 +517,7 @@ export function createControlsRoutes(ctx: ControlsRoutesContext): Router {
     const currentConfigFiles = ctx.getCurrentConfigFiles();
 
     const script: ScriptConfig | undefined = currentConfigs[configIndex]?.scripts?.find(
-      (item) => item.id === scriptId,
+      (item: ScriptConfig) => item.id === scriptId,
     );
     if (!script) {
       return res.status(404).json({ error: 'Script not found in loaded configs' });

--- a/packages/service/src/routes/entities.routes.ts
+++ b/packages/service/src/routes/entities.routes.ts
@@ -55,7 +55,7 @@ export function createEntitiesRoutes(ctx: EntitiesRoutesContext): Router {
         const info: ConfigEntityInfo = {
           entityId,
           entityName,
-          entityType,
+          entityType: entityType as string,
           portId,
         };
 
@@ -144,7 +144,12 @@ export function createEntitiesRoutes(ctx: EntitiesRoutesContext): Router {
       return res.status(429).json({ error: 'Too many requests' });
     }
 
-    const { entityId, newName, portId, updateObjectId = true } = req.body as {
+    const {
+      entityId,
+      newName,
+      portId,
+      updateObjectId = true,
+    } = req.body as {
       entityId?: string;
       newName?: string;
       portId?: string;

--- a/packages/service/src/routes/packets.routes.ts
+++ b/packages/service/src/routes/packets.routes.ts
@@ -210,7 +210,7 @@ export function createPacketToolsRoutes(ctx: PacketToolsRoutesContext): Router {
     const result = instance.bridge.constructCustomPacket(hex, { header, footer, checksum });
     if (!result.success || !result.packet) return res.status(400).json({ error: result.error });
 
-    const packetBytes = result.packet.match(/.{1,2}/g)?.map((x) => parseInt(x, 16));
+    const packetBytes = result.packet.match(/.{1,2}/g)?.map((x: string) => parseInt(x, 16));
 
     if (!packetBytes) {
       return res.status(400).json({ error: 'Failed to generate packet bytes from hex' });


### PR DESCRIPTION
🧹 Housekeeper: Fix implicit any types and type mismatches in service

🧹 Cleanup:
- Added explicit type annotations in `controls.routes.ts` and `packets.routes.ts` to satisfy `noImplicitAny`.
- Fixed type mismatches in `config.routes.ts` and `entities.routes.ts` where strict types were conflicting (TS2345, TS2731, TS2322).

✨ Benefit:
- Improves type safety in the service package.
- Reduces noise when running stricter TypeScript checks.
- Prevents potential runtime issues with object interpolation by using explicit string conversion.

🛡️ Verification:
- Ran `pnpm --filter @rs485-homenet/service exec tsc --noEmit --noUnusedLocals --noUnusedParameters` to confirm targeted errors are resolved.
- Verified that remaining errors are only related to build environment module resolution (known issue).


---
*PR created automatically by Jules for task [5253639528245035427](https://jules.google.com/task/5253639528245035427) started by @wooooooooooook*