### PR TITLE
⚡ Bolt: Optimize matchesPacket loop unswitching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -25,3 +25,7 @@
 ## 2026-01-30 - Pre-resolved Dispatch vs Switch
 **Learning:** In hot parsing loops, even a simple `switch` statement inside a helper function (like `verifyChecksum2FromBuffer`) adds measurable overhead (~13%) compared to calling a pre-resolved function reference directly. V8's monomorphic call optimization works best when the target function is stable and known ahead of time.
 **Action:** For high-frequency operations configured at startup (like checksum algorithms), pre-resolve the specific implementation function into a class property instead of passing the type string to a generic dispatcher function repeatedly.
+
+## 2026-02-03 - Loop Unswitching in Packet Matching
+**Learning:** In hot loops (like packet byte matching), checking `mask !== undefined` or `Array.isArray(mask)` inside the loop adds significant overhead (27% slowdown for scalar masks). V8 optimizes much better when the loop body is monomorphic and simple.
+**Action:** Unswitch loops based on configuration (No Mask, Scalar Mask, Array Mask) to create specialized, simple loop bodies for each case.


### PR DESCRIPTION
⚡ Bolt: Optimized `matchesPacket` loop

💡 **What:** Refactored `matchesPacket` in `packages/core/src/utils/packet-matching.ts` to use loop unswitching. Instead of checking mask type inside the byte comparison loop, it now selects one of three specialized loops (No Mask, Scalar Mask, Array Mask) before iterating.

🎯 **Why:** The `matchesPacket` function is a hot path called for every device on every packet. The previous implementation incurred overhead from repeated `undefined` checks and polymorphic mask handling inside the loop.

📊 **Impact:**
- Global Mask: ~27% speedup (651ms -> 473ms)
- Array Mask: ~14% speedup (606ms -> 518ms)
- No Mask: ~7% speedup (437ms -> 408ms)

🔬 **Measurement:**
Verified using a local benchmark script (`packages/core/bench-matches-packet.ts`) running 10M iterations for each scenario.

---
*PR created automatically by Jules for task [2865314025730099934](https://jules.google.com/task/2865314025730099934) started by @wooooooooooook*