### PR TITLE
🎨 Palette: Accessibility improvements for Sidebar and Cards

### DIFF
--- a/packages/core/test/automation/field_aliases.test.ts
+++ b/packages/core/test/automation/field_aliases.test.ts
@@ -133,7 +133,7 @@ describe('Automation Field Aliases', () => {
 
     await vi.advanceTimersByTimeAsync(0);
     expect(mqttPublisher.publish).toHaveBeenCalledWith('start', '1', undefined);
-    
+
     await vi.advanceTimersByTimeAsync(100);
     expect(mqttPublisher.publish).not.toHaveBeenCalledWith('end', '2', undefined);
 

--- a/packages/ui/src/lib/components/EntityCard.svelte
+++ b/packages/ui/src/lib/components/EntityCard.svelte
@@ -74,7 +74,11 @@
     <div class="header-title">
       <h3>{entity.displayName}</h3>
       {#if entity.errorCount && entity.errorCount > 0}
-        <span class="error-indicator" aria-label={$t('dashboard.entity_card.error_label')}>
+        <span
+          class="error-indicator"
+          role="img"
+          aria-label={$t('dashboard.entity_card.error_label')}
+        >
           ❗️
         </span>
       {/if}

--- a/packages/ui/src/lib/components/Sidebar.svelte
+++ b/packages/ui/src/lib/components/Sidebar.svelte
@@ -34,7 +34,7 @@
       aria-current={activeView === 'dashboard' ? 'page' : undefined}
       onclick={() => handleNavClick('dashboard')}
     >
-      <span class="icon">📊</span>
+      <span class="icon" aria-hidden="true">📊</span>
       <span class="label">{$t('sidebar.dashboard')}</span>
     </button>
     <button
@@ -43,7 +43,7 @@
       aria-current={activeView === 'analysis' ? 'page' : undefined}
       onclick={() => handleNavClick('analysis')}
     >
-      <span class="icon">📈</span>
+      <span class="icon" aria-hidden="true">📈</span>
       <span class="label">{$t('sidebar.analysis')}</span>
     </button>
     <button
@@ -52,7 +52,7 @@
       aria-current={activeView === 'gallery' ? 'page' : undefined}
       onclick={() => handleNavClick('gallery')}
     >
-      <span class="icon">📦</span>
+      <span class="icon" aria-hidden="true">📦</span>
       <span class="label">{$t('sidebar.gallery')}</span>
     </button>
     <button
@@ -61,7 +61,7 @@
       aria-current={activeView === 'settings' ? 'page' : undefined}
       onclick={() => handleNavClick('settings')}
     >
-      <span class="icon">⚙️</span>
+      <span class="icon" aria-hidden="true">⚙️</span>
       <span class="label">{$t('sidebar.settings')}</span>
     </button>
   </nav>

--- a/packages/ui/src/lib/components/SystemTopology.svelte
+++ b/packages/ui/src/lib/components/SystemTopology.svelte
@@ -100,6 +100,7 @@
             stroke-width="2"
             stroke-linecap="round"
             stroke-linejoin="round"
+            aria-hidden="true"
           >
             <path
               d="M2 9a3 3 0 0 1 0 6v2a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-2a3 3 0 0 1 0-6V7a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2Z"
@@ -144,6 +145,7 @@
             stroke-width="2"
             stroke-linecap="round"
             stroke-linejoin="round"
+            aria-hidden="true"
           >
             <rect x="2" y="2" width="20" height="8" rx="2" ry="2" />
             <rect x="2" y="14" width="20" height="8" rx="2" ry="2" />
@@ -187,6 +189,7 @@
             stroke-width="2"
             stroke-linecap="round"
             stroke-linejoin="round"
+            aria-hidden="true"
           >
             <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
           </svg>

--- a/packages/ui/src/lib/utils/time.ts
+++ b/packages/ui/src/lib/utils/time.ts
@@ -38,7 +38,7 @@ export const formatRelativeTime = (timestamp: number, locale: string = 'ko') => 
   if (absDiff < 604800000) {
     return rtf.format(-Math.floor(absDiff / 86400000), 'day');
   }
-  
+
   // Fallback to absolute time for very old logs
   return formatTime(timestamp, locale, {
     month: 'numeric',


### PR DESCRIPTION
This PR improves accessibility by hiding decorative icons from screen readers in the Sidebar and SystemTopology components, reducing noise. It also ensures that the error indicator in EntityCard is correctly announced as an image with its label, rather than just reading the emoji character.

---
*PR created automatically by Jules for task [12834541480357840469](https://jules.google.com/task/12834541480357840469) started by @wooooooooooook*