### PR TITLE
🧹 Housekeeper: Remove unused import in service

### DIFF
--- a/packages/service/src/activity-log.service.ts
+++ b/packages/service/src/activity-log.service.ts
@@ -2,7 +2,6 @@ import {
   eventBus,
   type StateChangedEvent,
   type MqttMessageEvent,
-  type AutomationTriggeredEvent,
   type AutomationGuardEvent,
   type AutomationActionEvent,
   type ScriptActionEvent,


### PR DESCRIPTION
Removed unused `AutomationTriggeredEvent` import from `packages/service/src/activity-log.service.ts`.
Verified with `pnpm lint` and `pnpm test`.

---
*PR created automatically by Jules for task [15589845171073141835](https://jules.google.com/task/15589845171073141835) started by @wooooooooooook*