### PR TITLE
📜 Scribe: Fix tx_checksum CEL context documentation

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -27,3 +27,7 @@
 ## 2024-05-26 - Checksum Type Definition Gap
 **Learning:** `ChecksumType` in `packages/core/src/protocol/types.ts` is missing `samsung_xor` and `bestin_sum` which are implemented in `checksum.ts` and documented in `packet-defaults.md`.
 **Action:** A developer agent should update the `ChecksumType` union to include these missing types to ensure type safety and consistent API definition.
+
+## 2026-02-04 - CEL Context Verification
+**Learning:** The documentation for 'tx_checksum' incorrectly listed 'state' and 'states' variables as available, but the implementation strictly limits context to 'data' and 'len' for performance.
+**Action:** Always verify the specific context object passed to 'CelExecutor.execute()' in 'GenericDevice.ts' or 'CommandGenerator.ts' before documenting available variables for new CEL features.

--- a/docs/CEL_GUIDE.md
+++ b/docs/CEL_GUIDE.md
@@ -154,8 +154,7 @@ sensor:
 
 - `data`: 헤더와 명령 데이터를 포함한 배열 (List of int).
 - `len`: 전체 데이터 길이 (int).
-- `state`: 해당 장치의 현재 상태 맵 (Map).
-- `states`: 전체 엔티티의 상태 맵 (Map).
+- **주의**: `state` 및 `states` 변수는 사용할 수 없습니다.
 
 ### 7. 동적 패킷 길이 (`rx_length_expr`)
 


### PR DESCRIPTION
💡 **What**: Updated `docs/CEL_GUIDE.md` to remove `state` and `states` from the list of available variables in the `tx_checksum` section.
🎯 **Why**: The documentation was misleading. The codebase (`GenericDevice.ts`, `CommandGenerator.ts`) strictly limits the context for checksum calculations to `data` and `len` to minimize object allocation overhead in hot paths.
📖 **Preview**:
```markdown
#### 송신 체크섬 (`tx_checksum`)
...
- `data`: 헤더와 명령 데이터를 포함한 배열 (List of int).
- `len`: 전체 데이터 길이 (int).
- **주의**: `state` 및 `states` 변수는 사용할 수 없습니다.
```
🧪 **Verification**:
- Verified source code in `packages/core/src/protocol/devices/generic.device.ts` and `packages/core/src/protocol/generators/command.generator.ts`.
- Ran `npx prettier` to ensure markdown formatting is consistent.

---
*PR created automatically by Jules for task [14891111601950015237](https://jules.google.com/task/14891111601950015237) started by @wooooooooooook*