### PR TITLE
🧹 Housekeeper: Remove unused `stateProvider` from `CommandGenerator`

### DIFF
--- a/.jules/housekeeper.md
+++ b/.jules/housekeeper.md
@@ -21,3 +21,7 @@
 ## 2025-05-23 - Global Linting Enabled
 **Observation:** The `lint` script in `package.json` was restricted to `service` and its dependencies, excluding `simulator` and `ui`.
 **Action:** Updated `package.json` to use `turbo lint` without filters, ensuring all packages are linted in the standard workflow. This resolves the previous observation "Simulator Excluded from Root Lint".
+
+## 2026-02-04 - Unused CommandGenerator Class
+**Observation:** The `CommandGenerator` class in `packages/core` appears to be unused in production code, only referenced in tests and exported in `index.ts`. It contains logic superseded by `PacketProcessor` and `Device` classes.
+**Action:** Removed unused `stateProvider` parameter to reduce noise. Future cleanup should investigate if the entire class can be deprecated or removed.

--- a/packages/core/src/protocol/generators/command.generator.ts
+++ b/packages/core/src/protocol/generators/command.generator.ts
@@ -11,7 +11,6 @@ import { FanEntity } from '../../domain/entities/fan.entity.js';
 import { SwitchEntity } from '../../domain/entities/switch.entity.js';
 import { ChecksumType, Checksum2Type, StateNumSchema } from '../types.js';
 import { logger } from '../../utils/logger.js';
-import { EntityStateProvider } from '../packet-processor.js';
 import { calculateChecksum, calculateChecksum2 } from '../utils/checksum.js';
 import { CelExecutor } from '../cel-executor.js';
 import { Buffer } from 'buffer';
@@ -47,9 +46,8 @@ export class CommandGenerator {
 
   /**
    * @param config - Global bridge configuration (contains default packet settings like retries, timeouts).
-   * @param stateProvider - Interface to access current entity states (needed for CEL checksum calculations).
    */
-  constructor(config: HomenetBridgeConfig, stateProvider: EntityStateProvider) {
+  constructor(config: HomenetBridgeConfig) {
     this.config = config;
     this.celExecutor = CelExecutor.shared();
   }

--- a/packages/core/test/checksum2.test.ts
+++ b/packages/core/test/checksum2.test.ts
@@ -155,12 +155,7 @@ describe('2-Byte Checksum', () => {
         },
       };
 
-      const mockStateProvider = {
-        getLightState: () => undefined,
-        getClimateState: () => undefined,
-      } as any;
-
-      const generator = new CommandGenerator(mockConfig, mockStateProvider);
+      const generator = new CommandGenerator(mockConfig);
 
       const mockEntity = {
         id: 'test',

--- a/packages/core/test/protocol/checksum_generation.test.ts
+++ b/packages/core/test/protocol/checksum_generation.test.ts
@@ -3,11 +3,6 @@ import { CommandGenerator } from '../../src/protocol/generators/command.generato
 import { HomenetBridgeConfig } from '../../src/config/types';
 
 describe('Command Generator - Checksum Logic', () => {
-  const mockStateProvider = {
-    getAllStates: () => ({}),
-    getEntityState: () => ({}),
-  } as any;
-
   const createConfig = (defaults: any): HomenetBridgeConfig =>
     ({
       homenet_bridge: {
@@ -37,7 +32,7 @@ describe('Command Generator - Checksum Logic', () => {
       tx_header: [0xf7],
       tx_checksum: 'add',
     });
-    const generator = new CommandGenerator(config, mockStateProvider);
+    const generator = new CommandGenerator(config);
     const packet = generator.constructCommandPacket(mockEntity, 'command_on');
 
     // F7 + 01 = F8
@@ -49,7 +44,7 @@ describe('Command Generator - Checksum Logic', () => {
       tx_header: [0xf7],
       tx_checksum: 'xor',
     });
-    const generator = new CommandGenerator(config, mockStateProvider);
+    const generator = new CommandGenerator(config);
     const packet = generator.constructCommandPacket(mockEntity, 'command_on');
 
     // F7 ^ 01 = F6
@@ -61,7 +56,7 @@ describe('Command Generator - Checksum Logic', () => {
       tx_header: [0xf7],
       tx_checksum: 'data[0] + 1', // F7 + 1 = F8
     });
-    const generator = new CommandGenerator(config, mockStateProvider);
+    const generator = new CommandGenerator(config);
     const packet = generator.constructCommandPacket(mockEntity, 'command_on');
 
     expect(packet).toEqual([0xf7, 0x01, 0xf8]);
@@ -72,7 +67,7 @@ describe('Command Generator - Checksum Logic', () => {
       tx_header: [0xf7],
       tx_checksum: '"string"', // Invalid return type
     });
-    const generator = new CommandGenerator(config, mockStateProvider);
+    const generator = new CommandGenerator(config);
     const packet = generator.constructCommandPacket(mockEntity, 'command_on');
 
     // Should log error and append 0
@@ -87,7 +82,7 @@ describe('Command Generator - Checksum Logic', () => {
       tx_checksum2: 'xor_add',
       // tx_checksum is undefined here
     });
-    const generator = new CommandGenerator(config, mockStateProvider);
+    const generator = new CommandGenerator(config);
     const packet = generator.constructCommandPacket(mockEntity, 'command_on');
 
     // XOR: F7 ^ 01 = F6
@@ -101,7 +96,7 @@ describe('Command Generator - Checksum Logic', () => {
       tx_header: [0xf7],
       tx_checksum2: '[0xAA, 0xBB]',
     });
-    const generator = new CommandGenerator(config, mockStateProvider);
+    const generator = new CommandGenerator(config);
     const packet = generator.constructCommandPacket(mockEntity, 'command_on');
 
     expect(packet).toEqual([0xf7, 0x01, 0xaa, 0xbb]);
@@ -112,7 +107,7 @@ describe('Command Generator - Checksum Logic', () => {
       tx_header: [0xf7],
       tx_checksum2: '[0xAA]', // Only 1 byte
     });
-    const generator = new CommandGenerator(config, mockStateProvider);
+    const generator = new CommandGenerator(config);
     const packet = generator.constructCommandPacket(mockEntity, 'command_on');
 
     expect(packet).toEqual([0xf7, 0x01, 0x00, 0x00]);
@@ -126,7 +121,7 @@ describe('Command Generator - Checksum Logic', () => {
       tx_checksum: 'none',
       tx_checksum2: 'xor_add',
     });
-    const generator = new CommandGenerator(config, mockStateProvider);
+    const generator = new CommandGenerator(config);
     const packet = generator.constructCommandPacket(mockEntity, 'command_on');
 
     expect(packet).toEqual([0xf7, 0x01, 0xf6, 0xee]);
@@ -139,7 +134,7 @@ describe('Command Generator - Checksum Logic', () => {
       tx_checksum: 'add',
       tx_checksum2: 'xor_add',
     });
-    const generator = new CommandGenerator(config, mockStateProvider);
+    const generator = new CommandGenerator(config);
     const packet = generator.constructCommandPacket(mockEntity, 'command_on');
 
     // Should use 'add' (1-byte)
@@ -154,7 +149,7 @@ describe('Command Generator - Checksum Logic', () => {
       tx_header: [0xf7],
       tx_checksum: 'unknown_algo',
     });
-    const generator = new CommandGenerator(config, mockStateProvider);
+    const generator = new CommandGenerator(config);
 
     const packet = generator.constructCommandPacket(mockEntity, 'command_on');
 


### PR DESCRIPTION
🧹 **Cleanup**: Removed the unused `stateProvider` parameter from `CommandGenerator` constructor and its associated unused import `EntityStateProvider`.

✨ **Benefit**: Reduces code clutter and removes a TypeScript `noUnusedLocals` / `noUnusedParameters` warning. Clarifies that `CommandGenerator` does not depend on state state provider.

🛡️ **Verification**:
- Ran `pnpm --filter @rs485-homenet/core exec tsc --noEmit --noUnusedLocals --noUnusedParameters` to verify the error is gone.
- Ran `pnpm --filter @rs485-homenet/core test` to ensure no regressions in affected tests (`checksum_generation.test.ts`, `checksum2.test.ts`).
- Ran `pnpm build` to ensure no breaking changes in other packages (confirmed `CommandGenerator` is unused in other packages).

---
*PR created automatically by Jules for task [7649688687855581470](https://jules.google.com/task/7649688687855581470) started by @wooooooooooook*