### PR TITLE
fix: enable optimistic updates for virtual entities without commands

### DIFF
--- a/packages/core/src/protocol/packet-processor.ts
+++ b/packages/core/src/protocol/packet-processor.ts
@@ -195,6 +195,21 @@ export class PacketProcessor extends EventEmitter {
       return null;
     }
 
+    // Handle Optimistic Updates
+    if (entity.optimistic) {
+      const optimisticState = device.getOptimisticState(commandName, value);
+      if (optimisticState) {
+        // Emit state update immediately
+        this.emit('state', { deviceId: entity.id, state: optimisticState });
+      }
+
+      // If no command packet was generated (virtual switch), return empty array
+      // so the caller treats it as "processed" instead of "failed"
+      if (!cmd) {
+        return [];
+      }
+    }
+
     if (!cmd) {
       const lastError = device.getLastError();
       const recentlyErrored =
@@ -210,21 +225,6 @@ export class PacketProcessor extends EventEmitter {
         });
       }
       return null;
-    }
-
-    // Handle Optimistic Updates
-    if (entity.optimistic) {
-      const optimisticState = device.getOptimisticState(commandName, value);
-      if (optimisticState) {
-        // Emit state update immediately
-        this.emit('state', { deviceId: entity.id, state: optimisticState });
-      }
-
-      // If no command packet was generated (virtual switch), return empty array
-      // so the caller treats it as "processed" instead of "failed"
-      if (!cmd) {
-        return [];
-      }
     }
 
     return cmd;


### PR DESCRIPTION
PacketProcessor was previously returning an error if a command packet could not be constructed (e.g. missing command_on/off), preventing optimistic state updates from firing. This change moves the optimistic handling logic before the error check, allowing entities configured with "optimistic: true" and no command data to function as virtual switches (returning an empty packet array []).

---
*PR created automatically by Jules for task [789664551200197006](https://jules.google.com/task/789664551200197006) started by @wooooooooooook*