### PR TITLE
Fix optimistic entity initialization publishing

### DIFF
--- a/packages/core/src/state/state-manager.ts
+++ b/packages/core/src/state/state-manager.ts
@@ -107,10 +107,9 @@ export class StateManager {
         if (entity.optimistic && entity.id) {
           // Only initialize if not already in deviceStates
           if (!this.deviceStates.has(entity.id)) {
-            this.deviceStates.set(entity.id, { ...defaultState });
-            if (this.sharedStates) {
-              this.sharedStates.set(entity.id, { ...defaultState });
-            }
+            // Use applyStateUpdate to ensure publishing and event emission
+            // This ensures state is retained in MQTT and visible to UI/HA immediately
+            this.applyStateUpdate(entity.id, { ...defaultState });
             logger.debug(
               `[StateManager] Initialized optimistic entity ${entity.id} with default state: ${JSON.stringify(defaultState)}`,
             );

--- a/packages/core/test/state/optimistic_init.test.ts
+++ b/packages/core/test/state/optimistic_init.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { StateManager } from '../../src/state/state-manager.js';
+import { PacketProcessor } from '../../src/protocol/packet-processor.js';
+import { MqttPublisher } from '../../src/transports/mqtt/publisher.js';
+import { HomenetBridgeConfig } from '../../src/config/types.js';
+
+describe('StateManager Optimistic Initialization', () => {
+  let stateManager: StateManager;
+  let mockPacketProcessor: PacketProcessor;
+  let mockMqttPublisher: MqttPublisher;
+  let config: HomenetBridgeConfig;
+  const PORT_ID = 'test-port';
+  const TOPIC_PREFIX = 'homenet';
+
+  beforeEach(() => {
+    mockPacketProcessor = {
+      on: vi.fn(),
+      processChunk: vi.fn(),
+    } as any;
+
+    mockMqttPublisher = {
+      publish: vi.fn(),
+    } as any;
+
+    config = {
+      serial: {
+        portId: PORT_ID,
+        path: '/dev/mock',
+      },
+      switch: [
+        {
+          id: 'virtual_switch',
+          name: 'Virtual Switch',
+          type: 'switch',
+          optimistic: true
+          // No command or data, purely virtual
+        } as any,
+      ],
+    };
+  });
+
+  it('should publish initial state for optimistic entities on startup', () => {
+    stateManager = new StateManager(
+      PORT_ID,
+      config,
+      mockPacketProcessor,
+      mockMqttPublisher,
+      TOPIC_PREFIX,
+    );
+
+    // Check if state is stored internally
+    const state = stateManager.getEntityState('virtual_switch');
+    expect(state).toEqual({ state: 'off' });
+
+    // Check if state was published to MQTT
+    // The topic should be prefix/entityId/state
+    const expectedTopic = `${TOPIC_PREFIX}/virtual_switch/state`;
+    const expectedPayload = JSON.stringify({ state: 'off' });
+
+    expect(mockMqttPublisher.publish).toHaveBeenCalledWith(
+      expectedTopic,
+      expectedPayload,
+      expect.objectContaining({ retain: true })
+    );
+  });
+});


### PR DESCRIPTION
Fixes an issue where optimistic entities (virtual switches) initialized with 'unknown' state instead of 'off'.
Modified `StateManager.initializeOptimisticEntities` to use `applyStateUpdate` instead of direct map assignment.
Added regression test.

---
*PR created automatically by Jules for task [1465049245170727565](https://jules.google.com/task/1465049245170727565) started by @wooooooooooook*