### PR TITLE
Fix MQTT state case sensitivity for Home Assistant compatibility

### DIFF
--- a/packages/core/src/protocol/devices/climate.device.ts
+++ b/packages/core/src/protocol/devices/climate.device.ts
@@ -60,4 +60,49 @@ export class ClimateDevice extends GenericDevice {
     // 3. Fallback to GenericDevice for everything else (static data, simple scripts if any)
     return super.constructCommand(commandName, value, states);
   }
+
+  public getOptimisticState(commandName: string, value?: any): Record<string, any> | null {
+    // Mode commands
+    if (commandName === 'mode' && value) {
+      return { mode: value }; // climate modes are typically lowercase (off, heat, cool)
+    }
+    if (commandName === 'off') {
+      return { mode: 'off' };
+    }
+    if (commandName === 'heat') {
+      return { mode: 'heat' };
+    }
+    if (commandName === 'cool') {
+      return { mode: 'cool' };
+    }
+    if (commandName === 'auto') {
+      return { mode: 'auto' };
+    }
+    if (commandName === 'dry') {
+      return { mode: 'dry' };
+    }
+    if (commandName === 'fan_only') {
+      return { mode: 'fan_only' };
+    }
+
+    // Temperature/Humidity
+    if (commandName === 'temperature' && typeof value === 'number') {
+      return { target_temperature: value };
+    }
+    if (commandName === 'humidity' && typeof value === 'number') {
+      return { target_humidity: value };
+    }
+
+    // Fan Mode
+    if (commandName === 'fan_mode' && value) {
+      return { fan_mode: value };
+    }
+
+    // Preset Mode
+    if (commandName === 'preset_mode' && value) {
+      return { preset_mode: value };
+    }
+
+    return null;
+  }
 }

--- a/packages/core/src/protocol/devices/lock.device.ts
+++ b/packages/core/src/protocol/devices/lock.device.ts
@@ -44,4 +44,14 @@ export class LockDevice extends GenericDevice {
 
     return null;
   }
+
+  public getOptimisticState(commandName: string, _value?: any): Record<string, any> | null {
+    if (commandName === 'lock') {
+      return { state: 'LOCKED' };
+    }
+    if (commandName === 'unlock') {
+      return { state: 'UNLOCKED' };
+    }
+    return null;
+  }
 }

--- a/packages/core/src/protocol/devices/valve.device.ts
+++ b/packages/core/src/protocol/devices/valve.device.ts
@@ -59,4 +59,24 @@ export class ValveDevice extends GenericDevice {
     // Fallback to GenericDevice for any other command_* that has data defined
     return super.constructCommand(commandName, value, states);
   }
+
+  public getOptimisticState(commandName: string, value?: any): Record<string, any> | null {
+    if (commandName === 'open') {
+      return { state: 'OPEN' };
+    }
+    if (commandName === 'close') {
+      return { state: 'CLOSED' };
+    }
+    if (commandName === 'stop') {
+      // Stop doesn't necessarily imply a state without position, but usually it stops at current
+      // We might not want to update state optimistically for stop unless we know where it is
+      return null;
+    }
+    if (commandName === 'position' && typeof value === 'number') {
+      const position = Math.min(100, Math.max(0, Math.round(value)));
+      const state = position === 0 ? 'CLOSED' : 'OPEN';
+      return { position, state };
+    }
+    return null;
+  }
 }

--- a/packages/core/src/state/state-manager.ts
+++ b/packages/core/src/state/state-manager.ts
@@ -82,13 +82,13 @@ export class StateManager {
    */
   private initializeOptimisticEntities(config: HomenetBridgeConfig): void {
     const defaultStateByType: Record<string, Record<string, any>> = {
-      binary_sensor: { state: 'off' },
-      switch: { state: 'off' },
-      light: { state: 'off' },
-      valve: { state: 'closed' },
-      cover: { state: 'closed' },
-      fan: { state: 'off' },
-      lock: { state: 'locked' },
+      binary_sensor: { state: 'OFF' },
+      switch: { state: 'OFF' },
+      light: { state: 'OFF' },
+      valve: { state: 'CLOSED' },
+      cover: { state: 'CLOSED' },
+      fan: { state: 'OFF' },
+      lock: { state: 'LOCKED' },
       button: {}, // Buttons don't have persistent state
       sensor: {}, // Sensors need actual values, skip
       climate: {}, // Climate has complex state, skip

--- a/packages/core/test/state/optimistic_init.test.ts
+++ b/packages/core/test/state/optimistic_init.test.ts
@@ -50,12 +50,12 @@ describe('StateManager Optimistic Initialization', () => {
 
     // Check if state is stored internally
     const state = stateManager.getEntityState('virtual_switch');
-    expect(state).toEqual({ state: 'off' });
+    expect(state).toEqual({ state: 'OFF' });
 
     // Check if state was published to MQTT
     // The topic should be prefix/entityId/state
     const expectedTopic = `${TOPIC_PREFIX}/virtual_switch/state`;
-    const expectedPayload = JSON.stringify({ state: 'off' });
+    const expectedPayload = JSON.stringify({ state: 'OFF' });
 
     expect(mockMqttPublisher.publish).toHaveBeenCalledWith(
       expectedTopic,


### PR DESCRIPTION
This PR addresses a case sensitivity issue in MQTT state reporting that prevented Home Assistant from correctly interpreting state updates.

### Changes
1.  **`packages/core/src/state/state-manager.ts`**:
    -   Modified `initializeOptimisticEntities` to use Uppercase strings (`'OFF'`, `'CLOSED'`, `'LOCKED'`) instead of lowercase for default states. This aligns with Home Assistant's requirements for Binary Sensor, Switch, Light, Fan, Valve, and Lock entities.

2.  **`packages/core/src/protocol/devices/*.device.ts`**:
    -   **`ValveDevice`**: Implemented `getOptimisticState` to return `'OPEN'`/`'CLOSED'` (Uppercase).
    -   **`LockDevice`**: Implemented `getOptimisticState` to return `'LOCKED'`/`'UNLOCKED'` (Uppercase).
    -   **`ClimateDevice`**: Implemented `getOptimisticState` to handle mode changes (`'off'`, `'heat'`, `'cool'`) and temperature updates. Note that Climate modes remain lowercase as per Home Assistant convention.

3.  **Tests**:
    -   Updated `packages/core/test/state/optimistic_init.test.ts` to assert that initialized states are Uppercase.

### Verification
-   Ran `packages/core/test/state/optimistic_init.test.ts` to confirm the fix works as expected.
-   Reviewed `discovery-manager.ts` and `state-normalizer.ts` to ensure the new default states align with discovery payloads and parsing logic.


---
*PR created automatically by Jules for task [14569301848209870546](https://jules.google.com/task/14569301848209870546) started by @wooooooooooook*