### PR TITLE
Deprecate CommandGenerator class

### DIFF
--- a/.jules/housekeeper.md
+++ b/.jules/housekeeper.md
@@ -25,3 +25,7 @@
 ## 2026-02-04 - Unused CommandGenerator Class
 **Observation:** The `CommandGenerator` class in `packages/core` appears to be unused in production code, only referenced in tests and exported in `index.ts`. It contains logic superseded by `PacketProcessor` and `Device` classes.
 **Action:** Removed unused `stateProvider` parameter to reduce noise. Future cleanup should investigate if the entire class can be deprecated or removed.
+
+## 2026-02-04 - Deprecated CommandGenerator
+**Observation:** `CommandGenerator` is verified to be unused in production code (replaced by `PacketProcessor` and `Device`).
+**Action:** Marked the class with `@deprecated` to warn developers and signal future removal.

--- a/packages/core/src/protocol/generators/command.generator.ts
+++ b/packages/core/src/protocol/generators/command.generator.ts
@@ -27,6 +27,9 @@ import { Buffer } from 'buffer';
  * - Encoding values (numbers/strings) into byte arrays (handling BCD, endianness, etc.).
  * - Assembling the full packet with Header, Data, and Footer.
  * - Calculating Checksums (1-byte, 2-byte, or CEL-based).
+ *
+ * @deprecated This class is superseded by `PacketProcessor` and `Device` logic.
+ *             It is maintained for legacy tests but should not be used in new code.
  */
 export class CommandGenerator {
   private config: HomenetBridgeConfig;


### PR DESCRIPTION
🧹 Cleanup: Deprecated the `CommandGenerator` class in `packages/core`.
✨ Benefit: This class is superseded by `PacketProcessor` and `Device` logic and is unused in production code. Marking it deprecated prevents accidental usage in new code.
🛡️ Verification: Ran `pnpm build` and `pnpm test` in `packages/core`. Verified that the single test failure in `field_aliases.test.ts` is pre-existing and unrelated to this change.

---
*PR created automatically by Jules for task [8934394906202069091](https://jules.google.com/task/8934394906202069091) started by @wooooooooooook*