### PR TITLE
feat(ui): hide 'no status' message for button entities

### DIFF
--- a/packages/ui/src/lib/components/EntityCard.svelte
+++ b/packages/ui/src/lib/components/EntityCard.svelte
@@ -123,7 +123,7 @@
         {:else}
           <strong class="payload-raw">{entity.statePayload}</strong>
         {/if}
-      {:else}
+      {:else if entity.type !== 'button'}
         <span class="no-status">{$t('dashboard.entity_card.no_status')}</span>
       {/if}
     </div>

--- a/packages/ui/src/lib/components/EntityDetail.svelte
+++ b/packages/ui/src/lib/components/EntityDetail.svelte
@@ -938,7 +938,7 @@
                   <span class="payload-value">{item.value}</span>
                 </div>
               {/each}
-              {#if !entity.statePayload}
+              {#if !entity.statePayload && entity.type !== 'button'}
                 <div class="no-data">{$t('entity_detail.status.no_data')}</div>
               {/if}
             </div>


### PR DESCRIPTION
This PR modifies the `EntityCard` and `EntityDetail` components in the UI package to suppress "No state information" or "No data" messages specifically for entities of type `button`. Since button entities are typically stateless (trigger-only), displaying a "missing status" message is confusing to users.

Changes:
- `packages/ui/src/lib/components/EntityCard.svelte`: Added a check `entity.type !== 'button'` before rendering the `no-status` span.
- `packages/ui/src/lib/components/EntityDetail.svelte`: Added a check `entity.type !== 'button'` before rendering the `no-data` div in the status tab.

---
*PR created automatically by Jules for task [6229965732541799607](https://jules.google.com/task/6229965732541799607) started by @wooooooooooook*