### PR TITLE
Fix gallery compatibility check for array requirements

### DIFF
--- a/packages/service/src/routes/gallery.routes.ts
+++ b/packages/service/src/routes/gallery.routes.ts
@@ -37,6 +37,7 @@ import {
 import type { LogRetentionService } from '../log-retention.service.js';
 import type { RateLimiter } from '../utils/rate-limiter.js';
 import type { PersistableHomenetBridgeConfig } from '../types/index.js';
+import { checkConfigRequirements, matchRequirement } from '../utils/gallery-requirements.js';
 
 export interface GalleryRoutesContext {
   configRateLimiter: RateLimiter;
@@ -224,95 +225,6 @@ export function createGalleryRoutes(ctx: GalleryRoutesContext): Router {
 
     return res.json({ compatibilityByVendorId });
   });
-
-  // Helper to check if a config matches vendor requirements
-  function checkConfigRequirements(
-    config: HomenetBridgeConfig,
-    requirements: { serial?: Record<string, unknown>; packet_defaults?: Record<string, unknown> },
-  ): boolean {
-    if (!config.serial) return false;
-
-    // Helper for flexible matching
-    const matchRequirement = (expected: unknown, actual: unknown): boolean => {
-      // 1. List matching (Array)
-      if (Array.isArray(expected)) {
-        // If actual value is in the expected array, it's a match
-        return expected.includes(actual);
-      }
-
-      // 2. Range matching (Object with min/max)
-      if (
-        typeof expected === 'object' &&
-        expected !== null &&
-        ('min' in expected || 'max' in expected)
-      ) {
-        const range = expected as { min?: number; max?: number };
-        if (typeof actual !== 'number') return false;
-
-        if (range.min !== undefined && actual < range.min) return false;
-        if (range.max !== undefined && actual > range.max) return false;
-        return true;
-      }
-
-      // 3. Exact matching (Primitive or simple object)
-      // Normalize values: treat empty arrays, null, and undefined as equivalent (empty/default)
-      const normalizeValue = (v: unknown): string | unknown => {
-        if (v === null || v === undefined) return '__EMPTY__';
-        if (Array.isArray(v) && v.length === 0) return '__EMPTY__';
-        if (Array.isArray(v)) return JSON.stringify(v);
-        return v;
-      };
-
-      return normalizeValue(expected) === normalizeValue(actual);
-    };
-
-    // Check serial settings
-    if (requirements.serial) {
-      const serialFields = ['baud_rate', 'data_bits', 'parity', 'stop_bits'];
-      for (const field of serialFields) {
-        const expected = requirements.serial[field];
-        const actual = config.serial[field as keyof typeof config.serial];
-        
-        // Skip check if requirement is not defined
-        if (expected === undefined) continue;
-        
-        // actual can be undefined in config, need to handle it.
-        // If expected is defined but actual is undefined, it's a mismatch (unless expected allows undefined/null, but usually config MUST exist)
-        if (actual === undefined && expected !== undefined) return false;
-
-        if (!matchRequirement(expected, actual)) {
-          return false;
-        }
-      }
-    }
-
-    // Check packet_defaults
-    if (requirements.packet_defaults) {
-      const packetDefaults = config.packet_defaults || {};
-      const packetFields = [
-        'rx_length',
-        'rx_checksum',
-        'tx_checksum',
-        'rx_header',
-        'tx_header',
-        'rx_footer',
-        'tx_footer',
-      ];
-
-      for (const field of packetFields) {
-        const expected = requirements.packet_defaults[field];
-        const actual = packetDefaults[field as keyof typeof packetDefaults];
-
-        if (expected !== undefined) {
-           if (!matchRequirement(expected, actual)) {
-            return false;
-          }
-        }
-      }
-    }
-
-    return true;
-  }
 
   // Evaluate discovery schemas against packet dictionary
   router.get('/api/gallery/discovery', async (req, res) => {
@@ -705,7 +617,7 @@ export function createGalleryRoutes(ctx: GalleryRoutesContext): Router {
           for (const field of serialFields) {
             const expected = vendorRequirements.serial[field];
             const actual = serialConfig[field];
-            if (expected !== undefined && actual !== undefined && expected !== actual) {
+            if (expected !== undefined && actual !== undefined && !matchRequirement(expected, actual)) {
               compatibility.compatible = false;
               compatibility.mismatches.push({
                 field: `serial.${field}`,
@@ -734,15 +646,7 @@ export function createGalleryRoutes(ctx: GalleryRoutesContext): Router {
             const actual = packetDefaults[field];
 
             if (expected !== undefined) {
-              // Normalize values: treat empty arrays, null, and undefined as equivalent (empty/default)
-              const normalizeValue = (v: unknown): string | unknown => {
-                // Empty array, null, or undefined are all considered "empty"
-                if (v === null || v === undefined) return '__EMPTY__';
-                if (Array.isArray(v) && v.length === 0) return '__EMPTY__';
-                if (Array.isArray(v)) return JSON.stringify(v);
-                return v;
-              };
-              if (normalizeValue(expected) !== normalizeValue(actual)) {
+              if (!matchRequirement(expected, actual ?? null)) {
                 compatibility.compatible = false;
                 compatibility.mismatches.push({
                   field: `packet_defaults.${field}`,
@@ -785,7 +689,7 @@ export function createGalleryRoutes(ctx: GalleryRoutesContext): Router {
       const currentConfigs = ctx.getCurrentConfigs();
       const currentConfigFiles = ctx.getCurrentConfigFiles();
 
-      // Find the config file for this portId
+      // Find the config for this portId
       let targetConfigFile: string | null = null;
       let configIndex = -1;
 

--- a/packages/service/src/utils/gallery-requirements.ts
+++ b/packages/service/src/utils/gallery-requirements.ts
@@ -1,0 +1,95 @@
+import { HomenetBridgeConfig } from '@rs485-homenet/core';
+
+// Helper for flexible matching
+export const matchRequirement = (expected: unknown, actual: unknown): boolean => {
+  // Normalize values: treat empty arrays, null, and undefined as equivalent (empty/default)
+  const normalizeValue = (v: unknown): string | unknown => {
+    if (v === null || v === undefined) return '__EMPTY__';
+    if (Array.isArray(v) && v.length === 0) return '__EMPTY__';
+    if (Array.isArray(v)) return JSON.stringify(v);
+    return v;
+  };
+
+  // 1. List matching (Array)
+  if (Array.isArray(expected)) {
+    // Try exact match first (e.g. expected is [0xaa] and actual is [0xaa])
+    if (normalizeValue(expected) === normalizeValue(actual)) {
+      return true;
+    }
+
+    // Then try list match (e.g. expected is [[0xaa], [0xbb]] and actual is [0xaa])
+    return expected.some((expItem) => normalizeValue(expItem) === normalizeValue(actual));
+  }
+
+  // 2. Range matching (Object with min/max)
+  if (
+    typeof expected === 'object' &&
+    expected !== null &&
+    ('min' in expected || 'max' in expected)
+  ) {
+    const range = expected as { min?: number; max?: number };
+    if (typeof actual !== 'number') return false;
+
+    if (range.min !== undefined && actual < range.min) return false;
+    if (range.max !== undefined && actual > range.max) return false;
+    return true;
+  }
+
+  // 3. Exact matching (Primitive or simple object)
+  return normalizeValue(expected) === normalizeValue(actual);
+};
+
+// Helper to check if a config matches vendor requirements
+export function checkConfigRequirements(
+  config: HomenetBridgeConfig,
+  requirements: { serial?: Record<string, unknown>; packet_defaults?: Record<string, unknown> },
+): boolean {
+  if (!config.serial) return false;
+
+  // Check serial settings
+  if (requirements.serial) {
+    const serialFields = ['baud_rate', 'data_bits', 'parity', 'stop_bits'];
+    for (const field of serialFields) {
+      const expected = requirements.serial[field];
+      const actual = config.serial[field as keyof typeof config.serial];
+
+      // Skip check if requirement is not defined
+      if (expected === undefined) continue;
+
+      // actual can be undefined in config, need to handle it.
+      // If expected is defined but actual is undefined, it's a mismatch (unless expected allows undefined/null, but usually config MUST exist)
+      if (actual === undefined && expected !== undefined) return false;
+
+      if (!matchRequirement(expected, actual)) {
+        return false;
+      }
+    }
+  }
+
+  // Check packet_defaults
+  if (requirements.packet_defaults) {
+    const packetDefaults = config.packet_defaults || {};
+    const packetFields = [
+      'rx_length',
+      'rx_checksum',
+      'tx_checksum',
+      'rx_header',
+      'tx_header',
+      'rx_footer',
+      'tx_footer',
+    ];
+
+    for (const field of packetFields) {
+      const expected = requirements.packet_defaults[field];
+      const actual = packetDefaults[field as keyof typeof packetDefaults];
+
+      if (expected !== undefined) {
+         if (!matchRequirement(expected, actual)) {
+          return false;
+        }
+      }
+    }
+  }
+
+  return true;
+}

--- a/packages/service/test/routes/gallery-requirements.test.ts
+++ b/packages/service/test/routes/gallery-requirements.test.ts
@@ -1,170 +1,85 @@
 import { describe, it, expect } from 'vitest';
 import { HomenetBridgeConfig } from '@rs485-homenet/core';
-
-// We need to test the checkConfigRequirements logic.
-// Since it's not exported from gallery.routes.ts and is inside the file scope,
-// we'll copy the logic here for unit testing to ensure correctness,
-// or simpler, we can extract it to a utility file if we wanted to be cleaner.
-// For now, I will create a test that mocks the matching logic to verify expected behavior.
-
-// Re-implementing the function locally for testing purposes as it was added as a local helper
-function checkConfigRequirements(
-  config: HomenetBridgeConfig,
-  requirements: { serial?: Record<string, unknown>; packet_defaults?: Record<string, unknown> },
-): boolean {
-  if (!config.serial) return false;
-
-  // Check serial settings
-  if (requirements.serial) {
-    const serialFields = ['baud_rate', 'data_bits', 'parity', 'stop_bits'];
-    for (const field of serialFields) {
-      const expected = requirements.serial[field];
-      const actual = config.serial[field as keyof typeof config.serial];
-      if (expected !== undefined && actual !== undefined && expected !== actual) {
-        return false;
-      }
-    }
-  }
-
-  // Check packet_defaults
-  if (requirements.packet_defaults) {
-    const packetDefaults = config.packet_defaults || {};
-    const packetFields = [
-      'rx_length',
-      'rx_checksum',
-      'tx_checksum',
-      'rx_header',
-      'tx_header',
-      'rx_footer',
-      'tx_footer',
-    ];
-
-    for (const field of packetFields) {
-      const expected = requirements.packet_defaults[field];
-      const actual = packetDefaults[field as keyof typeof packetDefaults];
-
-      if (expected !== undefined) {
-        const normalizeValue = (v: unknown): string | unknown => {
-          if (v === null || v === undefined) return '__EMPTY__';
-          if (Array.isArray(v) && v.length === 0) return '__EMPTY__';
-          if (Array.isArray(v)) return JSON.stringify(v);
-          return v;
-        };
-
-        if (normalizeValue(expected) !== normalizeValue(actual)) {
-          return false;
-        }
-      }
-    }
-  }
-
-  return true;
-}
+import { checkConfigRequirements } from '../../src/utils/gallery-requirements.js';
 
 describe('checkConfigRequirements', () => {
-  it('should return true when requirements match config', () => {
-    const config: HomenetBridgeConfig = {
+  const baseConfig: HomenetBridgeConfig = {
       serial: {
-        port: '/dev/ttyUSB0',
+        path: '/dev/ttyUSB0',
         baud_rate: 9600,
         data_bits: 8,
         parity: 'none',
         stop_bits: 1,
+        portId: 'default'
       },
       packet_defaults: {
         rx_header: [0xaa],
       },
-      mqtt: { broker_url: '' }, // minimal required
-    };
+  };
 
+  it('should return true when requirements match config', () => {
     const requirements = {
       serial: { baud_rate: 9600, parity: 'none' },
       packet_defaults: { rx_header: [0xaa] },
     };
 
-    expect(checkConfigRequirements(config, requirements)).toBe(true);
+    expect(checkConfigRequirements(baseConfig, requirements)).toBe(true);
   });
 
   it('should return false when baud_rate mismatches', () => {
-    const config: HomenetBridgeConfig = {
-      serial: {
-        port: '/dev/ttyUSB0',
-        baud_rate: 9600,
-        data_bits: 8,
-        parity: 'none',
-        stop_bits: 1,
-      },
-      mqtt: { broker_url: '' },
-    };
-
     const requirements = {
       serial: { baud_rate: 19200 },
     };
 
-    expect(checkConfigRequirements(config, requirements)).toBe(false);
+    expect(checkConfigRequirements(baseConfig, requirements)).toBe(false);
   });
 
   it('should return false when packet_defaults mismatch', () => {
-    const config: HomenetBridgeConfig = {
-      serial: {
-        port: '/dev/ttyUSB0',
-        baud_rate: 9600,
-        data_bits: 8,
-        parity: 'none',
-        stop_bits: 1,
-      },
-      packet_defaults: {
-        rx_header: [0xaa],
-      },
-      mqtt: { broker_url: '' },
-    };
-
     const requirements = {
       packet_defaults: { rx_header: [0xbb] },
     };
 
-    expect(checkConfigRequirements(config, requirements)).toBe(false);
+    expect(checkConfigRequirements(baseConfig, requirements)).toBe(false);
   });
 
   it('should treat null/undefined/empty array as equivalent in packet_defaults', () => {
     const config: HomenetBridgeConfig = {
       serial: {
-        port: '/dev/ttyUSB0',
+        path: '/dev/ttyUSB0',
         baud_rate: 9600,
         data_bits: 8,
         parity: 'none',
         stop_bits: 1,
+        portId: 'default'
       },
       packet_defaults: {
         rx_header: [], // empty array
       },
-      mqtt: { broker_url: '' },
     };
 
     // requirement expects null (should match empty array)
+    // Note: If expected is null, normalizeValue returns '__EMPTY__'.
+    // If actual is [], normalizeValue returns '__EMPTY__'.
+    // Match!
     const req1 = {
       packet_defaults: { rx_header: null },
     };
-    expect(checkConfigRequirements(config, req1)).toBe(true);
-
-    // requirement expects undefined (should be ignored effectively if not present in object loop, but if passed explicitly as undefined it might trigger match logic depending on loop, but here JSON.stringify handles it)
-    // Actually our logic says: if expected !== undefined.
-    // If I explicitly pass undefined in the object, the loop 'for (const field of packetFields)'
-    // will see expected as undefined and skip the check.
+    // Type casting because HomenetBridgeConfig types might be strict but runtime allows it
+    expect(checkConfigRequirements(config, req1 as any)).toBe(true);
 
     // Test explicit empty array requirement matching null config
     const config2: HomenetBridgeConfig = {
       serial: {
-        port: '/dev/ttyUSB0',
+        path: '/dev/ttyUSB0',
         baud_rate: 9600,
         data_bits: 8,
         parity: 'none',
         stop_bits: 1,
+        portId: 'default'
       },
       packet_defaults: {
         // rx_header undefined
       },
-      mqtt: { broker_url: '' },
     };
 
     const req2 = {

--- a/packages/service/test/utils/gallery-requirements.test.ts
+++ b/packages/service/test/utils/gallery-requirements.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { HomenetBridgeConfig } from '@rs485-homenet/core';
+import { checkConfigRequirements, matchRequirement } from '../../src/utils/gallery-requirements.js';
+
+describe('matchRequirement', () => {
+    it('should match primitive values (exact)', () => {
+        expect(matchRequirement(9600, 9600)).toBe(true);
+        expect(matchRequirement('none', 'none')).toBe(true);
+        expect(matchRequirement(9600, 19200)).toBe(false);
+    });
+
+    it('should match primitive values (list)', () => {
+        expect(matchRequirement([9600, 19200], 9600)).toBe(true);
+        expect(matchRequirement([9600, 19200], 19200)).toBe(true);
+        expect(matchRequirement([9600, 19200], 38400)).toBe(false);
+    });
+
+    it('should match primitive values (range)', () => {
+        expect(matchRequirement({ min: 9000, max: 10000 }, 9600)).toBe(true);
+        expect(matchRequirement({ min: 9000, max: 10000 }, 8000)).toBe(false);
+    });
+
+    it('should match array values (exact)', () => {
+        // rx_header: [0xaa]
+        expect(matchRequirement([0xaa], [0xaa])).toBe(true);
+        expect(matchRequirement([0xaa, 0xbb], [0xaa, 0xbb])).toBe(true);
+        expect(matchRequirement([0xaa], [0xbb])).toBe(false);
+    });
+
+    it('should match array values (list)', () => {
+        // rx_header: [[0xaa], [0xbb]]
+        expect(matchRequirement([[0xaa], [0xbb]], [0xaa])).toBe(true);
+        expect(matchRequirement([[0xaa], [0xbb]], [0xbb])).toBe(true);
+        expect(matchRequirement([[0xaa], [0xbb]], [0xcc])).toBe(false);
+    });
+});
+
+describe('checkConfigRequirements', () => {
+  const baseConfig: HomenetBridgeConfig = {
+    serial: {
+      path: '/dev/ttyUSB0',
+      baud_rate: 9600,
+      data_bits: 8,
+      parity: 'none',
+      stop_bits: 1,
+      portId: 'default'
+    },
+    packet_defaults: {
+      rx_header: [0xaa],
+    },
+  };
+
+  it('should pass correct config', () => {
+      expect(checkConfigRequirements(baseConfig, {
+          serial: { baud_rate: 9600 },
+          packet_defaults: { rx_header: [0xaa] }
+      })).toBe(true);
+  });
+});


### PR DESCRIPTION
This PR fixes an issue where gallery items with array-based requirements (like `rx_header`) were incorrectly flagged as incompatible. This was caused by the matching logic treating all arrays as "lists of allowed values" and failing strict reference equality checks against the actual array configuration.

Changes:
- Created `packages/service/src/utils/gallery-requirements.ts` to centralize and fix matching logic.
- Updated `matchRequirement` to prioritize exact array value matching before falling back to list inclusion checks.
- Refactored `packages/service/src/routes/gallery.routes.ts` to use this shared utility.
- Updated unit tests in `packages/service/test/routes/` to use the shared utility and verified behavior with `packages/service/test/utils/gallery-requirements.test.ts`.

---
*PR created automatically by Jules for task [12365888352665015639](https://jules.google.com/task/12365888352665015639) started by @wooooooooooook*