### PR TITLE
chore: standardize entity ID generation using romanization

### DIFF
--- a/packages/core/src/protocol/packet-processor.ts
+++ b/packages/core/src/protocol/packet-processor.ts
@@ -18,7 +18,7 @@ import { TextSensorDevice } from './devices/text-sensor.device.js';
 import { TextDevice } from './devices/text.device.js';
 import { BinarySensorDevice } from './devices/binary-sensor.device.js';
 import { ProtocolConfig, CommandResult } from './types.js';
-import { slugify } from '../utils/common.js';
+import { toEntityId } from '../utils/romanize.js';
 import { logger } from '../utils/logger.js';
 import type { EntityErrorEvent } from '../service/event-bus.js';
 
@@ -98,7 +98,7 @@ export class PacketProcessor extends EventEmitter {
       if (entities) {
         for (const entity of entities) {
           if (!entity.id && entity.name) {
-            entity.id = slugify(entity.name);
+            entity.id = toEntityId(entity.name);
             logger.debug(
               `[PacketProcessor] Generated ID for ${type}: ${entity.name} -> ${entity.id}`,
             );

--- a/packages/core/src/utils/common.ts
+++ b/packages/core/src/utils/common.ts
@@ -1,9 +1,0 @@
-export function slugify(text: string): string {
-  return text
-    .toString()
-    .toLowerCase()
-    .trim()
-    .replace(/\s+/g, '_') // Replace spaces with _
-    .replace(/[^\w\-]+/g, '') // Remove all non-word chars
-    .replace(/\-\-+/g, '_'); // Replace multiple - with _
-}

--- a/packages/core/src/utils/packet-analysis.ts
+++ b/packages/core/src/utils/packet-analysis.ts
@@ -21,7 +21,7 @@ import { SelectDevice } from '../protocol/devices/select.device.js';
 import { TextSensorDevice } from '../protocol/devices/text-sensor.device.js';
 import { TextDevice } from '../protocol/devices/text.device.js';
 import { BinarySensorDevice } from '../protocol/devices/binary-sensor.device.js';
-import { slugify } from './common.js';
+import { toEntityId } from './romanize.js';
 import { matchesPacket } from './packet-matching.js';
 import { logger } from './logger.js';
 import type { Device } from '../protocol/device.js';
@@ -116,7 +116,7 @@ const buildDevices = (config: HomenetBridgeConfig) => {
     if (!entities) continue;
     for (const entity of entities) {
       if (!entity.id && entity.name) {
-        entity.id = slugify(entity.name);
+        entity.id = toEntityId(entity.name);
         logger.debug(`[PacketAnalyzer] Generated ID for ${type}: ${entity.name} -> ${entity.id}`);
       }
       const DeviceClass = deviceMap[type] ?? GenericDevice;

--- a/packages/core/test/id_generation.test.ts
+++ b/packages/core/test/id_generation.test.ts
@@ -44,4 +44,39 @@ describe('ID Generation', () => {
     expect(devices.length).toBe(1);
     expect(devices[0].getId()).toBe('living_room_light');
   });
+
+  it('should romanize Korean name if ID is missing', () => {
+    const serial = {
+      portId: 'main',
+      baud_rate: 9600,
+      data_bits: 8,
+      parity: 'none',
+      stop_bits: 1,
+    } as any;
+    const config: HomenetBridgeConfig = {
+      serial,
+      packet_defaults: {},
+      light: [
+        {
+          name: '거실 조명',
+          state: { data: [0x01] },
+        } as any,
+      ],
+    };
+
+    const stateProvider = {
+      getLightState: () => undefined,
+      getClimateState: () => undefined,
+      getAllStates: () => ({}),
+      getEntityState: () => undefined,
+    };
+
+    const processor = new PacketProcessor(config, stateProvider);
+
+    const protocolManager = (processor as any).protocolManager as ProtocolManager;
+    const devices = (protocolManager as any).devices;
+
+    expect(devices.length).toBe(1);
+    expect(devices[0].getId()).toBe('geosil_jomyeong');
+  });
 });


### PR DESCRIPTION
Replaces the ad-hoc `slugify` function with the more robust `toEntityId` utility from `romanize.ts`. This ensures that entity names with Korean characters are correctly romanized into valid IDs instead of being stripped or replaced with underscores.

- Replaced `slugify` with `toEntityId` in `packages/core/src/protocol/packet-processor.ts` and `packages/core/src/utils/packet-analysis.ts`.
- Removed `packages/core/src/utils/common.ts` as `slugify` was its only export.
- Added a test case in `packages/core/test/id_generation.test.ts` to verify Korean name romanization.