### PR TITLE
Fix s6-overlay installation on arm64/buildx

### DIFF
--- a/hassio-addon-dev/Dockerfile
+++ b/hassio-addon-dev/Dockerfile
@@ -118,15 +118,16 @@ WORKDIR /app
 RUN apk add --no-cache bash jq gcompat curl xz
 
 # Install s6-overlay and bashio
-ARG BUILD_ARCH=amd64
+ARG TARGETARCH
+ARG TARGETVARIANT
 ARG S6_OVERLAY_VERSION="3.2.2.0"
 ARG BASHIO_VERSION="v0.17.5"
 RUN set -o pipefail \
     # Determine s6 architecture
-    && S6_ARCH="${BUILD_ARCH}" \
-    && if [ "${BUILD_ARCH}" = "amd64" ]; then S6_ARCH="x86_64"; fi \
-    && if [ "${BUILD_ARCH}" = "aarch64" ]; then S6_ARCH="aarch64"; fi \
-    && if [ "${BUILD_ARCH}" = "armv7" ]; then S6_ARCH="arm"; fi \
+    && S6_ARCH="${TARGETARCH}" \
+    && if [ "${TARGETARCH}" = "amd64" ]; then S6_ARCH="x86_64"; fi \
+    && if [ "${TARGETARCH}" = "arm64" ]; then S6_ARCH="aarch64"; fi \
+    && if [ "${TARGETARCH}" = "arm" ]; then S6_ARCH="arm"; fi \
     # Download and install s6-overlay
     && curl -L -s -f "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
         | tar -C / -Jxpf - \

--- a/hassio-addon/Dockerfile
+++ b/hassio-addon/Dockerfile
@@ -124,15 +124,16 @@ WORKDIR /app
 RUN apk add --no-cache bash jq gcompat curl xz
 
 # Install s6-overlay and bashio
-ARG BUILD_ARCH=amd64
+ARG TARGETARCH
+ARG TARGETVARIANT
 ARG S6_OVERLAY_VERSION="3.2.2.0"
 ARG BASHIO_VERSION="v0.17.5"
 RUN set -o pipefail \
     # Determine s6 architecture
-    && S6_ARCH="${BUILD_ARCH}" \
-    && if [ "${BUILD_ARCH}" = "amd64" ]; then S6_ARCH="x86_64"; fi \
-    && if [ "${BUILD_ARCH}" = "aarch64" ]; then S6_ARCH="aarch64"; fi \
-    && if [ "${BUILD_ARCH}" = "armv7" ]; then S6_ARCH="arm"; fi \
+    && S6_ARCH="${TARGETARCH}" \
+    && if [ "${TARGETARCH}" = "amd64" ]; then S6_ARCH="x86_64"; fi \
+    && if [ "${TARGETARCH}" = "arm64" ]; then S6_ARCH="aarch64"; fi \
+    && if [ "${TARGETARCH}" = "arm" ]; then S6_ARCH="arm"; fi \
     # Download and install s6-overlay
     && curl -L -s -f "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
         | tar -C / -Jxpf - \


### PR DESCRIPTION
This PR fixes a critical issue where `arm64` Docker builds were defaulting to `amd64` architecture logic because `BUILD_ARCH` is not automatically populated by `buildx`. 

Changes:
- Replaced `ARG BUILD_ARCH` with `ARG TARGETARCH` and `ARG TARGETVARIANT` in `hassio-addon/Dockerfile` and `hassio-addon-dev/Dockerfile`.
- Updated the architecture mapping logic to use `TARGETARCH`:
  - `amd64` -> `x86_64`
  - `arm64` -> `aarch64`
  - `arm` -> `arm` (for armv7)
- This ensures the correct `s6-overlay` binary is downloaded and installed, preventing execution errors on ARM platforms.

---
*PR created automatically by Jules for task [2168955214732800517](https://jules.google.com/task/2168955214732800517) started by @wooooooooooook*