### PR TITLE
feat(core): Home Assistant 라이트 색온도 kelvin 전환 반영

### DIFF
--- a/docs/config/light.md
+++ b/docs/config/light.md
@@ -9,7 +9,7 @@
 
 ## 옵션 필드 (상태)
 - 밝기: `state_brightness` — [`StateNumSchema`](./schemas.md#statenumschema).
-- 색온도(미레드): `state_color_temp` + `min_mireds`, `max_mireds`.
+- 색온도(켈빈): `state_color_temp_kelvin` + `min_color_temp_kelvin`, `max_color_temp_kelvin`. (구버전 호환: `state_color_temp`, `min_mireds`, `max_mireds`)
 - RGB: `state_red`, `state_green`, `state_blue` — 각각 `StateNumSchema`.
 - 화이트 채널: `state_white`.
 - 색상 모드: `state_color_mode` (`rgb`, `color_temp`, `white`).
@@ -17,7 +17,7 @@
 
 ## 옵션 필드 (명령)
 - 밝기: `command_brightness`.
-- 색온도: `command_color_temp`.
+- 색온도: `command_color_temp_kelvin`. (구버전 호환: `command_color_temp`)
 - RGB: `command_red`, `command_green`, `command_blue`.
 - 화이트 채널: `command_white`.
 - 효과: `command_effect`.
@@ -47,10 +47,11 @@
   - `rgb_command_topic`: `${MQTT_TOPIC_PREFIX}/${id}/rgb/set`
   - `rgb_value_template`: <code v-pre>{{ value_json.red }},{{ value_json.green }},{{ value_json.blue }}</code>
 - 색온도 지원 시
-  - `color_temp_state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
-  - `color_temp_command_topic`: `${MQTT_TOPIC_PREFIX}/${id}/color_temp/set`
-  - `color_temp_value_template`: <code v-pre>{{ value_json.color_temp }}</code>
-  - 선택: `min_mireds`, `max_mireds`
+  - `color_temp_kelvin_state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`
+  - `color_temp_kelvin_command_topic`: `${MQTT_TOPIC_PREFIX}/${id}/color_temp_kelvin/set`
+  - `color_temp_kelvin_value_template`: <code v-pre>{{ value_json.color_temp_kelvin }}</code>
+  - 선택: `min_color_temp_kelvin`, `max_color_temp_kelvin`
+  - 레거시 설정(`min_mireds`, `max_mireds`) 사용 시 내부적으로 kelvin 값으로 변환되어 발행됩니다.
 - 효과 지원 시
   - `effect_list`
   - `effect_state_topic`: `${MQTT_TOPIC_PREFIX}/${id}/state`

--- a/docs/guide/entity-examples.md
+++ b/docs/guide/entity-examples.md
@@ -455,17 +455,17 @@ light:
     state_on: { offset: 1, data: [0x01] }
     state_off: { offset: 1, data: [0x00] }
     state_brightness: { offset: 2, length: 1 }
-    state_color_temp: { offset: 3, length: 2 }  # mireds
+    state_color_temp_kelvin: { offset: 3, length: 2 }  # kelvin
     
-    min_mireds: 153  # 6500K (차가운 백색)
-    max_mireds: 500  # 2000K (따뜻한 백색)
+    min_color_temp_kelvin: 2000  # 따뜻한 백색
+    max_color_temp_kelvin: 6500  # 차가운 백색
     
     command_on: { data: [0x32, 0x01] }
     command_off: { data: [0x32, 0x00] }
     command_brightness:
       data: [0x32, 0x01, 0x00]
       value_offset: 2
-    command_color_temp:
+    command_color_temp_kelvin:
       data: [0x32, 0x01, 0x00, 0x00, 0x00]
       value_offset: 3
       length: 2
@@ -474,7 +474,7 @@ light:
 **지원하는 기능:**
 - **Brightness**: 0-255
 - **RGB Color**: Red, Green, Blue (각 0-255)
-- **Color Temperature**: mireds 단위
+- **Color Temperature**: kelvin 단위 (레거시 mired 설정도 호환)
 - **White Value**: 백색 채널
 - **Effects**: 이펙트 리스트
 

--- a/packages/core/src/domain/entities/light.entity.ts
+++ b/packages/core/src/domain/entities/light.entity.ts
@@ -12,7 +12,13 @@ export interface LightEntity extends EntityConfig {
   state_brightness?: StateNumSchemaOrCEL;
   command_brightness?: CommandSchemaOrCEL;
 
-  // Color temperature support (mireds)
+  // Color temperature support (kelvin)
+  state_color_temp_kelvin?: StateNumSchemaOrCEL;
+  command_color_temp_kelvin?: CommandSchemaOrCEL;
+  min_color_temp_kelvin?: number;
+  max_color_temp_kelvin?: number;
+
+  // Deprecated: mired-based color temperature support
   state_color_temp?: StateNumSchemaOrCEL;
   command_color_temp?: CommandSchemaOrCEL;
   min_mireds?: number;

--- a/packages/core/src/mqtt/discovery-manager.ts
+++ b/packages/core/src/mqtt/discovery-manager.ts
@@ -396,17 +396,27 @@ export class DiscoveryManager {
             '{{ value_json.red }},{{ value_json.green }},{{ value_json.blue }}';
         }
 
-        // Color temperature support (mireds)
-        if (entity.state_color_temp || entity.command_color_temp) {
-          payload.color_temp_state_topic = `${this.mqttTopicPrefix}/${id}/state`;
-          payload.color_temp_command_topic = `${this.mqttTopicPrefix}/${id}/color_temp/set`;
-          payload.color_temp_value_template = '{{ value_json.color_temp }}';
+        // Color temperature support (kelvin)
+        if (
+          entity.state_color_temp_kelvin ||
+          entity.command_color_temp_kelvin ||
+          entity.state_color_temp ||
+          entity.command_color_temp
+        ) {
+          payload.color_temp_kelvin_state_topic = `${this.mqttTopicPrefix}/${id}/state`;
+          payload.color_temp_kelvin_command_topic = `${this.mqttTopicPrefix}/${id}/color_temp_kelvin/set`;
+          payload.color_temp_kelvin_value_template = '{{ value_json.color_temp_kelvin }}';
 
-          if (entity.min_mireds !== undefined) {
-            payload.min_mireds = entity.min_mireds;
+          if (entity.min_color_temp_kelvin !== undefined) {
+            payload.min_color_temp_kelvin = entity.min_color_temp_kelvin;
+          } else if (entity.max_mireds !== undefined && entity.max_mireds > 0) {
+            payload.min_color_temp_kelvin = Math.round(1000000 / entity.max_mireds);
           }
-          if (entity.max_mireds !== undefined) {
-            payload.max_mireds = entity.max_mireds;
+
+          if (entity.max_color_temp_kelvin !== undefined) {
+            payload.max_color_temp_kelvin = entity.max_color_temp_kelvin;
+          } else if (entity.min_mireds !== undefined && entity.min_mireds > 0) {
+            payload.max_color_temp_kelvin = Math.round(1000000 / entity.min_mireds);
           }
         }
 

--- a/packages/core/src/protocol/devices/light.device.ts
+++ b/packages/core/src/protocol/devices/light.device.ts
@@ -56,7 +56,28 @@ export class LightDevice extends GenericDevice {
       return this.framePacket(command);
     }
 
-    // Handle color temperature command
+    // Handle color temperature command (kelvin first, then legacy mireds)
+    if (
+      commandName === 'color_temp_kelvin' &&
+      typeof entityConfig.command_color_temp_kelvin !== 'string' &&
+      entityConfig.command_color_temp_kelvin?.data &&
+      value !== undefined
+    ) {
+      const command = [...entityConfig.command_color_temp_kelvin.data];
+      const valueOffset = (entityConfig.command_color_temp_kelvin as any).value_offset;
+      const length = (entityConfig.command_color_temp_kelvin as any).length || 2;
+      if (valueOffset !== undefined) {
+        const val = Math.round(value);
+        if (length === 2) {
+          command[valueOffset] = (val >> 8) & 0xff;
+          command[valueOffset + 1] = val & 0xff;
+        } else {
+          command[valueOffset] = val;
+        }
+      }
+      return this.framePacket(command);
+    }
+
     if (
       commandName === 'color_temp' &&
       typeof entityConfig.command_color_temp !== 'string' &&
@@ -73,6 +94,27 @@ export class LightDevice extends GenericDevice {
           command[valueOffset + 1] = val & 0xff;
         } else {
           command[valueOffset] = val;
+        }
+      }
+      return this.framePacket(command);
+    }
+
+    if (
+      commandName === 'color_temp_kelvin' &&
+      typeof entityConfig.command_color_temp !== 'string' &&
+      entityConfig.command_color_temp?.data &&
+      value !== undefined
+    ) {
+      const command = [...entityConfig.command_color_temp.data];
+      const valueOffset = (entityConfig.command_color_temp as any).value_offset;
+      const length = (entityConfig.command_color_temp as any).length || 2;
+      if (valueOffset !== undefined) {
+        const mired = Math.round(1000000 / Math.max(1, Number(value)));
+        if (length === 2) {
+          command[valueOffset] = (mired >> 8) & 0xff;
+          command[valueOffset + 1] = mired & 0xff;
+        } else {
+          command[valueOffset] = mired;
         }
       }
       return this.framePacket(command);

--- a/packages/core/src/protocol/devices/state-normalizer.ts
+++ b/packages/core/src/protocol/devices/state-normalizer.ts
@@ -208,10 +208,18 @@ export const normalizeDeviceState = (
       }
     }
 
-    if (!normalized.color_temp && entityConfig.state_color_temp) {
+    if (!normalized.color_temp_kelvin && entityConfig.state_color_temp_kelvin) {
+      const colorTempKelvin = extractValue(payload, entityConfig.state_color_temp_kelvin, headerLen);
+      if (colorTempKelvin !== null) {
+        normalized.color_temp_kelvin = colorTempKelvin;
+      }
+    }
+
+    // Backward compatibility: legacy mireds field
+    if (!normalized.color_temp_kelvin && entityConfig.state_color_temp) {
       const colorTemp = extractValue(payload, entityConfig.state_color_temp, headerLen);
-      if (colorTemp !== null) {
-        normalized.color_temp = colorTemp;
+      if (typeof colorTemp === 'number' && colorTemp > 0) {
+        normalized.color_temp_kelvin = Math.round(1000000 / colorTemp);
       }
     }
 

--- a/packages/core/src/transports/mqtt/subscriber.ts
+++ b/packages/core/src/transports/mqtt/subscriber.ts
@@ -207,6 +207,11 @@ export class MqttSubscriber {
         }
       }
 
+      // Light color temperature: Home Assistant uses color_temp_kelvin
+      if (targetEntity.type === 'light' && commandName === 'color_temp') {
+        commandName = 'color_temp_kelvin';
+      }
+
       // Fan Percentage -> speed
       if (targetEntity.type === 'fan' && commandName === 'percentage') {
         commandName = 'speed';

--- a/packages/core/static/schema/homenet-bridge.schema.json
+++ b/packages/core/static/schema/homenet-bridge.schema.json
@@ -325,7 +325,7 @@
           ]
         },
         "state_brightness": {
-          "description": "Numeric state schema that can be either a structured schema object or a CEL expression string.\nCEL expressions are evaluated at runtime to extract numeric values from packet data.",
+          "description": "[Deprecated] Numeric state schema in mireds. Prefer state_color_temp_kelvin.",
           "anyOf": [
             {
               "$ref": "#/definitions/StateNumSchema"
@@ -336,7 +336,7 @@
           ]
         },
         "command_brightness": {
-          "description": "Command schema that can be either a structured schema object or a CEL expression string.\nCEL expressions are evaluated at runtime to construct the command packet.\nFor commands, the CEL expression often constructs the raw bytes directly.",
+          "description": "[Deprecated] Command schema in mireds. Prefer command_color_temp_kelvin.",
           "anyOf": [
             {
               "$ref": "#/definitions/CommandSchema"
@@ -345,6 +345,34 @@
               "type": "string"
             }
           ]
+        },
+        "state_color_temp_kelvin": {
+          "description": "Numeric state schema for color temperature in kelvin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StateNumSchema"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "command_color_temp_kelvin": {
+          "description": "Command schema for color temperature in kelvin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CommandSchema"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "min_color_temp_kelvin": {
+          "type": "number"
+        },
+        "max_color_temp_kelvin": {
+          "type": "number"
         },
         "state_color_temp": {
           "description": "Numeric state schema that can be either a structured schema object or a CEL expression string.\nCEL expressions are evaluated at runtime to extract numeric values from packet data.",

--- a/packages/core/test/climate_command.test.ts
+++ b/packages/core/test/climate_command.test.ts
@@ -58,6 +58,15 @@ describe('Climate Command Packet Generation', () => {
         rx_checksum: 'samsung_rx',
         tx_checksum: 'samsung_tx',
       },
+      light: [
+        {
+          id: 'light_1',
+          name: 'Light 1',
+          type: 'light',
+          state: { data: [0x30] },
+          command_color_temp: { data: [0x30, 0x03, 0x00, 0x00], value_offset: 2, length: 2 },
+        },
+      ],
       climate: [
         {
           id: 'room_0_heater',
@@ -106,6 +115,10 @@ describe('Climate Command Packet Generation', () => {
     mockPacketProcessor = {
       constructCommandPacket: vi.fn((entity, commandName, value) => {
         // Simulate command packet construction
+        if (entity.id === 'light_1' && commandName === 'color_temp_kelvin' && value !== undefined) {
+          return [0x30, 0x03, 0x01, 0xf4, 0x00];
+        }
+
         if (entity.id === 'room_0_heater') {
           if (commandName === 'off' && entity.command_off?.data) {
             // Return command_off data + checksum
@@ -213,4 +226,19 @@ describe('Climate Command Packet Generation', () => {
     expect(capturedCommands[1].command).toBe('temperature');
     expect(capturedCommands[1].value).toBe(22.5);
   });
+
+  it('should map light color_temp topic to color_temp_kelvin command', async () => {
+    const topic = 'homenet2mqtt/homedevice1/light_1/color_temp/set';
+    const message = Buffer.from('2000');
+
+    await (mqttSubscriber as any).handleMqttMessage(topic, message);
+
+    expect(mockPacketProcessor.constructCommandPacket).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'light_1' }),
+      'color_temp_kelvin',
+      2000,
+    );
+    expect(mockSerialPort.write).toHaveBeenCalled();
+  });
+
 });

--- a/packages/core/test/discovery_manager.test.ts
+++ b/packages/core/test/discovery_manager.test.ts
@@ -101,6 +101,16 @@ describe('DiscoveryManager', () => {
           state: {},
         },
         {
+          id: 'ct_light',
+          name: 'Color Temp Light',
+          type: 'light',
+          discovery_always: true,
+          state: {},
+          state_color_temp: { offset: 3, length: 2 },
+          min_mireds: 153,
+          max_mireds: 500,
+        },
+        {
           id: 'skipped_switch',
           name: 'Skipped Switch',
           type: 'switch',
@@ -272,4 +282,24 @@ describe('DiscoveryManager', () => {
     expect(payload.preset_mode_state_topic).toBe('homenet2mqtt/homedevice1/climate_custom/state');
     expect(payload.preset_mode_value_template).toBe('{{ value_json.preset_mode }}');
   });
+
+  it('라이트 색온도 Discovery는 kelvin 필드를 사용한다', () => {
+    discoveryManager.discover();
+
+    const topic = 'homeassistant/light/homenet_main_ct_light/config';
+    const call = mockPublisher.publish.mock.calls.find((args: any[]) => args[0] === topic);
+    expect(call).toBeDefined();
+
+    const payload = JSON.parse(call[1]);
+    expect(payload.color_temp_kelvin_state_topic).toBe('homenet2mqtt/homedevice1/ct_light/state');
+    expect(payload.color_temp_kelvin_command_topic).toBe(
+      'homenet2mqtt/homedevice1/ct_light/color_temp_kelvin/set',
+    );
+    expect(payload.color_temp_kelvin_value_template).toBe('{{ value_json.color_temp_kelvin }}');
+    expect(payload.min_color_temp_kelvin).toBe(2000);
+    expect(payload.max_color_temp_kelvin).toBe(6536);
+    expect(payload.min_mireds).toBeUndefined();
+    expect(payload.max_mireds).toBeUndefined();
+  });
+
 });

--- a/packages/core/test/entities/light.test.ts
+++ b/packages/core/test/entities/light.test.ts
@@ -64,7 +64,7 @@ describe('Light Entity', () => {
     const device = new LightDevice(lightConfig, protocolConfig);
     const packet = Buffer.from([0x30, 0x01, 0xff, 0x00, 0x00, 0x00, 0x01, 0xf4, 0x00]); // 500 mireds (0x01F4)
     const result = device.parseData(packet);
-    expect(result).toMatchObject({ color_temp: 500 });
+    expect(result).toMatchObject({ color_temp_kelvin: 2000 });
   });
 
   it('should parse white value', () => {
@@ -102,6 +102,12 @@ describe('Light Entity', () => {
   it('should construct color temp command', () => {
     const device = new LightDevice(lightConfig, protocolConfig);
     const command = device.constructCommand('color_temp', 500);
+    expect(command).toEqual([0x30, 0x03, 0x01, 0xf4]);
+  });
+
+  it('should construct color temp kelvin command using legacy mired schema', () => {
+    const device = new LightDevice(lightConfig, protocolConfig);
+    const command = device.constructCommand('color_temp_kelvin', 2000);
     expect(command).toEqual([0x30, 0x03, 0x01, 0xf4]);
   });
 

--- a/packages/core/test/protocol/devices/state-normalizer.test.ts
+++ b/packages/core/test/protocol/devices/state-normalizer.test.ts
@@ -66,14 +66,24 @@ describe('normalizeDeviceState', () => {
       });
     });
 
-    it('should normalize color temperature', () => {
+    it('should normalize color temperature kelvin directly', () => {
       const config = {
         type: 'light',
-        state_color_temp: { offset: 0, length: 1 },
+        state_color_temp_kelvin: { offset: 0, length: 2 },
       };
-      const payload = new Uint8Array([0x32]); // 50 decimal
+      const payload = new Uint8Array([0x0b, 0xb8]); // 3000K
       const result = normalizeDeviceState(config, payload, {});
-      expect(result).toEqual({ color_temp: 50 });
+      expect(result).toEqual({ color_temp_kelvin: 3000 });
+    });
+
+    it('should normalize legacy mired color temperature to kelvin', () => {
+      const config = {
+        type: 'light',
+        state_color_temp: { offset: 0, length: 2 },
+      };
+      const payload = new Uint8Array([0x01, 0xf4]); // 500 mireds
+      const result = normalizeDeviceState(config, payload, {});
+      expect(result).toEqual({ color_temp_kelvin: 2000 });
     });
   });
 


### PR DESCRIPTION
### Motivation

- Home Assistant의 색온도 필드가 mireds에서 kelvin 기반(`color_temp_kelvin`)으로 변경되어, 라이트 엔티티가 새 규격을 따르도록 코드와 문서를 업데이트할 필요가 있었습니다.

### Description

- `LightEntity`에 `state_color_temp_kelvin`, `command_color_temp_kelvin`, `min_color_temp_kelvin`, `max_color_temp_kelvin` 필드를 추가하고 기존 mired 필드는 레거시로 유지했습니다.
- 상태 정규화(`normalizeDeviceState`)에서 `color_temp_kelvin`을 우선 파싱하도록 변경하고, 레거시 `state_color_temp`(mireds)가 있는 경우 내부적으로 kelvin으로 변환해 `color_temp_kelvin`으로 노출하도록 했습니다.
- MQTT Discovery(`discovery-manager`)에서 라이트 색온도 페이로드를 `color_temp_kelvin_*` 토픽/템플릿과 `min/max_color_temp_kelvin` 필드로 발행하도록 변경하고, 기존 `min_mireds`/`max_mireds`가 있으면 kelvin으로 역변환해 채워주도록 했습니다.
- 라이트 명령 생성(`LightDevice.constructCommand`)에 `color_temp_kelvin` 처리 경로를 추가하고, `command_color_temp`(mireds)만 있는 장치에 대해 kelvin 입력을 mired로 변환해 전송하는 호환 로직을 추가했습니다.
- MQTT 구독자(`MqttSubscriber`)에서 들어오는 `.../color_temp/set` 토픽을 내부 명령 `color_temp_kelvin`으로 매핑하도록 변경했습니다.
- JSON 스키마(`packages/core/static/schema/homenet-bridge.schema.json`)와 문서(`docs/config/light.md`, `docs/guide/entity-examples.md`)를 kelvin 기반으로 업데이트했고, 관련 단위 테스트들을 보강/수정했습니다.

### Testing

- `pnpm build` (루트) — 실패: 기존의 서비스 타입 오류(`packages/service/src/routes/gallery.routes.ts(451,44)`)로 전체 빌드 중단이 발생했습니다.
- `pnpm lint` (루트) — 실패: 동일한 서비스 타입 오류로 실패했습니다.
- `pnpm test` (루트) — 실패: 서비스 빌드 오류로 전체 테스트 파이프라인이 중단되었습니다.
- `pnpm --filter @rs485-homenet/core build` — 성공으로 core 패키지 빌드와 스키마 생성은 통과했습니다.
- `pnpm --filter @rs485-homenet/core lint` — 성공으로 core 타입체크는 통과했습니다.
- 선택적 단위검증: `pnpm --filter @rs485-homenet/core exec vitest run ... --root ../..`로 대상 테스트(`entities/light.test.ts`, `protocol/devices/state-normalizer.test.ts`, `discovery_manager.test.ts`, `climate_command.test.ts`)를 실행했으며 모두 성공했습니다.
- 참고: `pnpm --filter @rs485-homenet/core test` 실행 시 레포지토리의 기존(본 PR과 무관한) 실패(`packages/core/test/romanize.test.ts`)와 일부 테스트에서 외부 에러가 보고되어 전체 테스트 통과에는 영향이 있었습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa016a2350832ca38fb86cf636e75c)