### PR TITLE
후원 QR 이미지 경로를 상대경로로 변경

### DIFF
--- a/docs/sponsor.md
+++ b/docs/sponsor.md
@@ -11,7 +11,7 @@
 아래 QR코드를 스마트폰으로 스캔하거나, 버튼을 클릭하여 후원할 수 있습니다.
 
 <div style="text-align: center; margin: 32px 0;">
-  <img src="/kakaopay-qr.png" alt="카카오페이 후원 QR코드" style="width: 220px; height: auto; border-radius: 12px; box-shadow: 0 4px 20px rgba(0,0,0,0.12);" />
+  <img src="./public/kakaopay-qr.png" alt="카카오페이 후원 QR코드" style="width: 220px; height: auto; border-radius: 12px; box-shadow: 0 4px 20px rgba(0,0,0,0.12);" />
   <p style="margin-top: 16px;">
     <a href="https://qr.kakaopay.com/Ej7qgjcVK" target="_blank" rel="noopener noreferrer"
        style="display: inline-block; padding: 10px 24px; border-radius: 8px; background: #fee500; color: #1a1a1a; font-weight: 700; text-decoration: none; font-size: 15px;">

--- a/packages/ui/src/lib/components/Sidebar.svelte
+++ b/packages/ui/src/lib/components/Sidebar.svelte
@@ -86,7 +86,7 @@
     <p class="sponsor-title">☕ 개발자 후원하기</p>
     <p class="sponsor-desc">카카오페이로 후원해 주세요</p>
     <button type="button" class="sponsor-qr-btn" onclick={handleSponsorClick} aria-label="후원하기">
-      <img src="/kakaopay-qr.png" alt="카카오페이 후원 QR코드" class="sponsor-qr" />
+      <img src="./kakaopay-qr.png" alt="카카오페이 후원 QR코드" class="sponsor-qr" />
     </button>
     <p class="sponsor-hint">{isMobile ? '탭하여 후원' : '클릭하면 크게 볼 수 있어요'}</p>
   </div>
@@ -107,7 +107,7 @@
         aria-label="닫기"
         onclick={() => (showSponsorModal = false)}>✕</button
       >
-      <img src="/kakaopay-qr.png" alt="카카오페이 후원 QR코드" class="sponsor-modal-img" />
+      <img src="./kakaopay-qr.png" alt="카카오페이 후원 QR코드" class="sponsor-modal-img" />
       <p class="sponsor-modal-label">homenet2mqtt 개발자 후원하기</p>
     </div>
   </div>


### PR DESCRIPTION
### Motivation
- UI가 배포 경로에 따라 QR 이미지 로딩에 실패하는 문제를 방지하고 문서와 코드의 경로 표기를 일치시키기 위해 이미지 경로를 상대경로로 변경했습니다.

### Description
- 사이드바에서 후원 버튼에 사용되는 QR 이미지 경로를 절대경로(`/kakaopay-qr.png`)에서 상대경로(`./kakaopay-qr.png`)로 변경했습니다 (`packages/ui/src/lib/components/Sidebar.svelte`).
- 후원 모달 내부의 QR 이미지 경로도 동일하게 상대경로로 변경했습니다 (`packages/ui/src/lib/components/Sidebar.svelte`).
- 문서의 QR 이미지 경로를 상대경로(`./public/kakaopay-qr.png`)로 맞춰 문서와 코드가 일치하도록 수정했습니다 (`docs/sponsor.md`).

### Testing
- `pnpm format`를 실행했으며 포맷팅이 정상 완료되었습니다.
- `pnpm build`를 실행해 UI 빌드 및 서비스 동기화가 성공했으며 빌드 중 기존 Svelte a11y 경고가 출력되었으나 빌드는 성공했습니다.
- `pnpm lint`를 실행했으며 Svelte 관련 경고(접근성)가 남아있지만 lint 작업은 성공했습니다.
- `pnpm test`를 실행해 `vitest` 기반의 테스트 스위트가 모두 통과했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad351f2da8832c9c3c32ae9012ed8a)