### PR TITLE
Reopen setup when all configured config files are missing and remove init marker

### DIFF
--- a/packages/service/src/server.ts
+++ b/packages/service/src/server.ts
@@ -742,6 +742,43 @@ server.listen(port, async () => {
 
     const uniqueConfigFiles = [...new Set(availableConfigFiles)];
 
+    const missingConfigFiles = (
+      await Promise.all(
+        uniqueConfigFiles.map(async (file) => {
+          const configPath = path.resolve(CONFIG_DIR, file);
+          const exists = await fileExists(configPath);
+          return exists ? null : file;
+        }),
+      )
+    ).filter((file): file is string => file !== null);
+
+    const allConfigFilesMissing =
+      uniqueConfigFiles.length > 0 && missingConfigFiles.length === uniqueConfigFiles.length;
+
+    if (allConfigFilesMissing) {
+      if (await fileExists(CONFIG_INIT_MARKER)) {
+        await fs.unlink(CONFIG_INIT_MARKER).catch(() => {});
+        logger.warn(
+          {
+            missingConfigFiles,
+            markerPath: CONFIG_INIT_MARKER,
+          },
+          '[service] Missing configured files detected. Removed .initialized marker to reopen setup wizard.',
+        );
+      }
+
+      bridgeStatus = 'error';
+      bridgeError = createBridgeErrorPayload({
+        code: 'CONFIG_INITIALIZATION_REQUIRED',
+        message: 'Configuration initialization required.',
+        source: 'service',
+        severity: 'error',
+        retryable: false,
+      });
+      currentConfigFiles = [];
+      return;
+    }
+
     if (uniqueConfigFiles.length === 0) {
       // 설정 파일이 없으면 초기 설정 마법사 표시
       bridgeStatus = 'error';


### PR DESCRIPTION
### Motivation
- Ensure the bridge enters setup mode if all configured configuration files are missing from disk so the user can reinitialize configuration.
- Remove stale initialization markers to prevent the service from appearing initialized when required config files are absent.

### Description
- Add a scan of `uniqueConfigFiles` to determine `missingConfigFiles` using `fileExists` and treat the case where all configured files are missing as an initialization-required error.
- When all configured files are missing and the `.initialized` marker exists, remove the marker with `fs.unlink` and log a warning containing `missingConfigFiles` and `markerPath`.
- Set `bridgeStatus` to `error`, populate `bridgeError` with a `CONFIG_INITIALIZATION_REQUIRED` payload, clear `currentConfigFiles`, and return early to show the setup wizard.
- Preserve the existing behavior for the case where no config files are present and log the original warning before returning.

### Testing
- Ran the project type check/build (`yarn build` / `tsc`) and it completed successfully.
- Ran the automated test suite (`yarn test`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0be6b2f60832cbc03d54cedd5565b)