### PR TITLE
StateSchema에 `index` 추가하고 `offset`을 레거시 alias로 지원하도록 변경

### DIFF
--- a/docs/config/schemas.md
+++ b/docs/config/schemas.md
@@ -23,7 +23,8 @@
 | 속성 | 타입 | 기본값 | 설명 |
 | --- | --- | --- | --- |
 | `data` | `number[]` | - | 패킷이 이 배열과 일치해야 합니다. |
-| `offset` | `number` | `rx_header`의 길이 | `data` 비교를 시작할 위치입니다. **생략 시 헤더 다음 바이트부터 매칭하고, 명시(0 포함) 시 헤더 포함 전체 패킷 기준 인덱스**입니다. |
+| `index` | `number` | `rx_header`의 길이 | `data` 비교를 시작할 위치입니다. **생략 시 헤더 다음 바이트부터 매칭하고, 명시(0 포함) 시 헤더 포함 전체 패킷 기준 인덱스**입니다. |
+| `offset` | `number` | - | `index`의 레거시 alias 입니다. 기존 설정 호환용으로만 유지됩니다. |
 | `mask` | `number` \| `number[]` | - | 비교 전 `(value & mask)`를 적용합니다. 특정 비트만 비교할 때 유용합니다. |
 | `inverted` | `boolean` | `false` | `true`면 매칭/추출 전에 비트를 반전(`~value`)합니다. |
 | `guard` | `string` | - | `data` 매칭 후 추가로 검증할 CEL 표현식입니다. |
@@ -32,7 +33,7 @@
 ### 실전 작성 가이드
 
 **Q: 헤더 다음 바이트가 `0x82 0x80 0x01`로 시작하는 패킷을 매칭하려면?**
-`offset`을 생략하면 헤더 다음 바이트부터 매칭합니다.
+`index`를 생략하면 헤더 다음 바이트부터 매칭합니다.
 ```yaml
 # rx_header: [0xF7]인 경우 → F7 82 80 01 ... 매칭
 state:
@@ -40,11 +41,11 @@ state:
 ```
 
 **Q: 헤더를 포함한 전체 패킷의 3번째 바이트(인덱스 2)가 `0x01`인 패킷은?**
-`offset`을 명시하면 헤더 포함 전체 패킷 기준으로 인덱스를 지정합니다.
+`index`를 명시하면 헤더 포함 전체 패킷 기준으로 인덱스를 지정합니다.
 ```yaml
 # rx_header: [0xF7]인 경우 → F7 xx 01 ... 매칭 (packet[2] = 0x01)
 state:
-  offset: 2
+  index: 2
   data: [0x01]
 ```
 
@@ -62,7 +63,7 @@ state:
 state:
   data: [0x82]
   except:
-    - offset: 1
+    - index: 1
       data: [0xEE]  # 0x82 0xEE ... 는 제외
 ```
 
@@ -90,7 +91,7 @@ state:
 
 # 매칭된 패킷의 2번 인덱스(3번째 바이트)를 온도로 사용
 state_temperature:
-  offset: 2
+  index: 2
   length: 1
 ```
 
@@ -98,7 +99,7 @@ state_temperature:
 오프셋 4부터 2바이트를 읽어 `23.5`(`235`)로 변환합니다.
 ```yaml
 state_temperature:
-  offset: 4
+  index: 4
   length: 2
   endian: big
   precision: 1
@@ -108,7 +109,7 @@ state_temperature:
 `0x12 0x34` → `1234`로 변환.
 ```yaml
 state_value:
-  offset: 5
+  index: 5
   length: 2
   decode: bcd
 ```
@@ -119,7 +120,7 @@ state_value:
 | 속성 | 타입 | 기본값 | 설명 |
 | --- | --- | --- | --- |
 | `data` | `number[]` | - | 전송할 기본 패킷 데이터. |
-| `ack` | `StateSchema` \| `number[]` | - | ACK 패킷 매칭 패턴. 정의된 경우 이 패턴에 매칭되는 패킷 **또는** `state:change` 이벤트가 발생하면 명령이 성공한 것으로 간주합니다. 배열로 지정하면 `{ data: [...] }` 형태의 `StateSchema`로 자동 변환됩니다. **`offset`을 생략하면 헤더 다음 바이트부터 매칭하고, `offset`을 명시(0 포함)하면 헤더 포함 전체 패킷 기준으로 매칭**합니다. |
+| `ack` | `StateSchema` \| `number[]` | - | ACK 패킷 매칭 패턴. 정의된 경우 이 패턴에 매칭되는 패킷 **또는** `state:change` 이벤트가 발생하면 명령이 성공한 것으로 간주합니다. 배열로 지정하면 `{ data: [...] }` 형태의 `StateSchema`로 자동 변환됩니다. **`index`를 생략하면 헤더 다음 바이트부터 매칭하고, `index`를 명시(0 포함)하면 헤더 포함 전체 패킷 기준으로 매칭**합니다. |
 
 | `value_offset` | `number` | - | 입력값을 삽입할 인덱스. |
 | `length` | `number` | `1` | 입력값이 차지할 바이트 길이. |
@@ -136,7 +137,7 @@ state_value:
 - **`ack`가 정의된 경우**: ACK 패킷 매칭 **또는** 해당 엔티티의 `state:change` 이벤트 중 **먼저 발생하는 것**을 ACK로 처리합니다.
 - **`ack`가 정의되지 않은 경우**: 기존처럼 `state:change` 이벤트만을 ACK로 대기합니다.
 - Button과 같이 `state:change` 이벤트가 발생하지 않는 엔티티에서는 `ack`를 반드시 정의해야 ACK를 수신할 수 있습니다.
-- `ack`는 위의 [StateSchema](#stateschema-패킷-매칭) 형식으로 정의할 수 있으며, `offset`, `mask`, `except` 등의 고급 매칭 옵션을 사용할 수 있습니다.
+- `ack`는 위의 [StateSchema](#stateschema-패킷-매칭) 형식으로 정의할 수 있으며, `index`(또는 legacy `offset`), `mask`, `except` 등의 고급 매칭 옵션을 사용할 수 있습니다.
 
 ### 스키마 기반 vs CEL 방식
 
@@ -255,7 +256,7 @@ button:
       data: [0x31, 0x01, 0x00]
       ack: [0x31, 0x81, 0x00]  # 0x31 0x81 0x00으로 시작하는 패킷을 ACK로 인식
 
-# StateSchema 형태 (offset, mask 등 고급 옵션 사용 가능)
+# StateSchema 형태 (index, mask 등 고급 옵션 사용 가능)
 button:
   - id: doorbell
     name: "초인종"
@@ -263,7 +264,7 @@ button:
       data: [0x42, 0x01]
       ack:
         data: [0x42]
-        offset: 0
+        index: 0
         mask: 0xFF
 ```
 
@@ -284,7 +285,7 @@ button:
   command_custom_preset: 'xstr == "Away" ? [0x01] : [0x02]'
   ```
 - `automation` 트리거/액션에서 패킷 매칭은 `StateSchema` 규칙을, 명령 실행은 `CommandSchema` 규칙을 그대로 따릅니다. 자세한 예제는 [AUTOMATION.md](../guide/automation.md)를 참고하세요.
-- `automation` 액션에 `update_state`를 사용할 수 있습니다. 패킷 트리거와 조합해 엔티티 상태를 직접 갱신하며, 값은 `StateSchema/StateNumSchema`로 정의합니다. `offset`은 수신된 원본 패킷 전체(rx_header 포함)를 기준으로 계산합니다. 모든 엔티티 타입에서 `parseData`와 동일한 해석을 적용합니다.
+- `automation` 액션에 `update_state`를 사용할 수 있습니다. 패킷 트리거와 조합해 엔티티 상태를 직접 갱신하며, 값은 `StateSchema/StateNumSchema`로 정의합니다. `index`는 수신된 원본 패킷 전체(rx_header 포함)를 기준으로 계산합니다. 모든 엔티티 타입에서 `parseData`와 동일한 해석을 적용합니다. (`offset`도 alias로 동작)
 - 설정 파일에서는 `automation` 대신 `automations`를 최상위 키로 선언해도 동일하게 동작합니다.
 - `update_state`는 대상 엔티티에 정의된 `state_*` 및 해당 속성명만 허용하며, 정의되지 않은 속성은 오류로 처리됩니다.
 

--- a/packages/core/src/automation/automation-manager.ts
+++ b/packages/core/src/automation/automation-manager.ts
@@ -38,6 +38,7 @@ import { findEntityById } from '../utils/entities.js';
 import { logger } from '../utils/logger.js';
 import { matchesPacket } from '../utils/packet-matching.js';
 import { normalizeDeviceState } from '../protocol/devices/state-normalizer.js';
+import { hasExplicitSchemaIndex } from '../protocol/schema-index.js';
 import {
   calculateChecksumFromBuffer,
   calculateChecksum2FromBuffer,
@@ -74,6 +75,7 @@ type CommandSender = (
 const SCHEMA_KEYS = [
   'data',
   'mask',
+  'index',
   'offset',
   'inverted',
   'guard',
@@ -482,7 +484,7 @@ export class AutomationManager {
     const match = trigger.match as StateSchema;
     // offset이 명시되지 않은 경우에만 headerLen을 baseOffset으로 사용
     const headerLen = this.config.packet_defaults?.rx_header?.length ?? 0;
-    const baseOffset = match?.offset === undefined ? headerLen : 0;
+    const baseOffset = hasExplicitSchemaIndex(match) ? 0 : headerLen;
     return matchesPacket(match, packet, { baseOffset });
   }
 
@@ -832,7 +834,7 @@ export class AutomationManager {
         if (this.isDataMatchSchema(rawValue)) {
           // offset이 명시되지 않은 경우에만 headerLen을 baseOffset으로 사용
           const headerLen = this.config.packet_defaults?.rx_header?.length ?? 0;
-          const baseOffset = rawValue.offset === undefined ? headerLen : 0;
+          const baseOffset = hasExplicitSchemaIndex(rawValue) ? 0 : headerLen;
           const matched = matchesPacket(rawValue, packetBuffer, {
             baseOffset,
             allowEmptyData: true,

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -41,7 +41,27 @@ function normalizeSerialConfig(serial: SerialConfig): SerialConfig {
   return normalized;
 }
 
+function normalizeIndexAlias(value: unknown): void {
+  if (!value || typeof value !== 'object') return;
+
+  if (Array.isArray(value)) {
+    value.forEach((item) => normalizeIndexAlias(item));
+    return;
+  }
+
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.index === 'number' && obj.offset === undefined) {
+    obj.offset = obj.index;
+  } else if (typeof obj.offset === 'number' && obj.index === undefined) {
+    obj.index = obj.offset;
+  }
+
+  Object.values(obj).forEach((child) => normalizeIndexAlias(child));
+}
+
 export function normalizeConfig(config: HomenetBridgeConfig) {
+  normalizeIndexAlias(config);
+
   const automationAlias = (config as any).automations;
   if (Array.isArray(automationAlias)) {
     if (Array.isArray(config.automation)) {

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -61,7 +61,7 @@ export interface AutomationTriggerPacket {
   type: 'packet';
   /**
    * Schema to match the received packet.
-   * `data` field is required. `offset` can be used to skip header.
+   * `data` field is required. `index` can be used to skip header.
    */
   match: StateSchema;
   /** Additional CEL condition. */

--- a/packages/core/src/protocol/device.ts
+++ b/packages/core/src/protocol/device.ts
@@ -11,6 +11,7 @@ import { extractFromSchema } from './schema-utils.js';
 import type { EntityErrorEvent, EntityErrorType } from '../service/event-bus.js';
 import { CelExecutor, CompiledScript, ReusableBufferView } from './cel-executor.js';
 import { logger } from '../utils/logger.js';
+import { hasExplicitSchemaIndex } from './schema-index.js';
 
 export abstract class Device {
   public config: DeviceConfig;
@@ -115,7 +116,7 @@ export abstract class Device {
     // offset이 명시되지 않은 경우에만 headerLength를 baseOffset으로 사용
     // offset이 명시된 경우(0 포함)는 헤더 포함 전체 패킷 기준
     const headerLength = this.protocolConfig.packet_defaults?.rx_header?.length || 0;
-    const baseOffset = stateConfig.offset === undefined ? headerLength : 0;
+    const baseOffset = hasExplicitSchemaIndex(stateConfig) ? 0 : headerLength;
 
     // Optimization: Update reusable view/context for zero-allocation guard execution
     if (this.reusableBufferView) {

--- a/packages/core/src/protocol/devices/generic.device.ts
+++ b/packages/core/src/protocol/devices/generic.device.ts
@@ -13,6 +13,7 @@ import {
 } from '../utils/checksum.js';
 import { logger } from '../../utils/logger.js';
 import { Buffer } from 'buffer';
+import { getSchemaIndex, hasExplicitSchemaIndex } from '../schema-index.js';
 
 interface StateScript {
   key: string;
@@ -375,7 +376,7 @@ export class GenericDevice extends Device {
     if (!stateSchema) return false;
     // offset이 명시되지 않은 경우에만 headerLen을 baseOffset으로 사용
     const headerLen = this.protocolConfig.packet_defaults?.rx_header?.length ?? 0;
-    const baseOffset = stateSchema.offset === undefined ? headerLen : 0;
+    const baseOffset = hasExplicitSchemaIndex(stateSchema) ? 0 : headerLen;
     return matchesPacket(stateSchema, packetData, {
       baseOffset,
       allowEmptyData: true,
@@ -397,14 +398,8 @@ export class GenericDevice extends Device {
    * @returns The extracted number or string, or `null` if extraction fails (e.g. out of bounds).
    */
   protected extractValue(bytes: Uint8Array, schema: StateNumSchema): number | string | null {
-    const {
-      offset,
-      length = 1,
-      precision = 0,
-      signed = false,
-      endian = 'big',
-      decode = 'none',
-    } = schema;
+    const { length = 1, precision = 0, signed = false, endian = 'big', decode = 'none' } = schema;
+    const offset = getSchemaIndex(schema);
 
     if (offset === undefined || offset + length > bytes.length) {
       return null;

--- a/packages/core/src/protocol/devices/state-normalizer.ts
+++ b/packages/core/src/protocol/devices/state-normalizer.ts
@@ -1,5 +1,6 @@
 import { matchesPacket } from '../../utils/packet-matching.js';
 import { StateSchema, StateNumSchema } from '../types.js';
+import { getSchemaIndex, hasExplicitSchemaIndex } from '../schema-index.js';
 
 export interface NormalizeStateOptions {
   headerLen?: number;
@@ -13,7 +14,7 @@ const matchesState = (
 ): boolean => {
   if (!schema) return false;
   const headerLen = options.headerLen ?? 0;
-  const baseOffset = schema.offset === undefined ? headerLen : 0;
+  const baseOffset = hasExplicitSchemaIndex(schema) ? 0 : headerLen;
   return matchesPacket(schema, payload, {
     baseOffset,
     allowEmptyData: true,
@@ -39,18 +40,12 @@ const extractValue = (
   schema: StateNumSchema,
   headerLen: number = 0,
 ): number | string | null => {
-  const {
-    offset: rawOffset,
-    length = 1,
-    precision = 0,
-    signed = false,
-    endian = 'big',
-    decode = 'none',
-  } = schema;
+  const { length = 1, precision = 0, signed = false, endian = 'big', decode = 'none' } = schema;
+  const rawIndex = getSchemaIndex(schema);
 
   // offset이 명시되지 않은 경우 headerLen을 기본값으로 사용 (헤더 다음부터)
   // offset이 명시된 경우 전체 패킷 기준으로 사용
-  const offset = rawOffset ?? headerLen;
+  const offset = rawIndex ?? headerLen;
 
   if (offset + length > bytes.length) {
     return null;
@@ -121,7 +116,7 @@ const extractValue = (
 const extractOption = (payload: Uint8Array, schema: any): string | null => {
   if (!schema || !schema.map) return null;
 
-  const offset = schema.offset || 0;
+  const offset = getSchemaIndex(schema) ?? 0;
   const length = schema.length || 1;
 
   if (payload.length < offset + length) return null;
@@ -283,7 +278,7 @@ export const normalizeDeviceState = (
       options,
     );
     if (directionFlag && entityConfig.state_direction) {
-      const offset = entityConfig.state_direction.offset || 0;
+      const offset = getSchemaIndex(entityConfig.state_direction) ?? 0;
       if (payload[offset] === 0) {
         normalized.direction = 'forward';
       } else {

--- a/packages/core/src/protocol/devices/text-sensor.device.ts
+++ b/packages/core/src/protocol/devices/text-sensor.device.ts
@@ -1,6 +1,7 @@
 import { GenericDevice } from './generic.device.js';
 import { ProtocolConfig, CommandResult } from '../types.js';
 import { TextSensorEntity } from '../../domain/entities/text-sensor.entity.js';
+import { getSchemaIndex } from '../schema-index.js';
 
 export class TextSensorDevice extends GenericDevice {
   constructor(config: TextSensorEntity, protocolConfig: ProtocolConfig) {
@@ -31,7 +32,7 @@ export class TextSensorDevice extends GenericDevice {
   private extractText(packet: Buffer, schema: any): string | null {
     if (!schema) return null;
 
-    const offset = schema.offset || 0;
+    const offset = getSchemaIndex(schema) ?? 0;
     const length = schema.length || 1;
 
     if (packet.length < offset + length) return null;

--- a/packages/core/src/protocol/devices/text.device.ts
+++ b/packages/core/src/protocol/devices/text.device.ts
@@ -1,6 +1,7 @@
 import { GenericDevice } from './generic.device.js';
 import { ProtocolConfig, CommandResult } from '../types.js';
 import { TextEntity } from '../../domain/entities/text.entity.js';
+import { getSchemaIndex } from '../schema-index.js';
 
 export class TextDevice extends GenericDevice {
   private optimisticValue: string | null = null;
@@ -46,7 +47,7 @@ export class TextDevice extends GenericDevice {
   private extractText(packet: Buffer, schema: any): string | null {
     if (!schema) return null;
 
-    const offset = schema.offset || 0;
+    const offset = getSchemaIndex(schema) ?? 0;
     const length = schema.length || 1;
 
     if (packet.length < offset + length) return null;

--- a/packages/core/src/protocol/schema-index.ts
+++ b/packages/core/src/protocol/schema-index.ts
@@ -1,0 +1,12 @@
+import { StateSchema } from './types.js';
+
+type SchemaWithIndex = Pick<StateSchema, 'index' | 'offset'>;
+
+export const getSchemaIndex = (schema: SchemaWithIndex | null | undefined): number | undefined => {
+  if (!schema) return undefined;
+  if (schema.index !== undefined) return schema.index;
+  return schema.offset;
+};
+
+export const hasExplicitSchemaIndex = (schema: SchemaWithIndex | null | undefined): boolean =>
+  getSchemaIndex(schema) !== undefined;

--- a/packages/core/src/protocol/schema-utils.ts
+++ b/packages/core/src/protocol/schema-utils.ts
@@ -1,8 +1,10 @@
 import { Buffer } from 'buffer';
 import { StateSchema, StateNumSchema } from './types.js';
+import { getSchemaIndex } from './schema-index.js';
 
 export const extractFromSchema = (packet: Buffer, schema: StateSchema | StateNumSchema): any => {
-  const { offset = 0, data, mask, inverted = false } = schema;
+  const offset = getSchemaIndex(schema) ?? 0;
+  const { data, mask, inverted = false } = schema;
   const numSchema = schema as StateNumSchema;
 
   // Determine length

--- a/packages/core/src/protocol/types.ts
+++ b/packages/core/src/protocol/types.ts
@@ -188,7 +188,13 @@ export interface StateSchema {
   mask?: number | number[];
 
   /**
-   * Byte offset in the packet payload where the state value is located.
+   * Byte index in the full packet where the state value is located.
+   */
+  index?: number;
+
+  /**
+   * Legacy alias for `index`.
+   * @deprecated Use `index` instead.
    */
   offset?: number;
 
@@ -272,13 +278,13 @@ export interface CommandResult {
 /**
  * State schema that can be either a structured schema object or a CEL expression string.
  * CEL expressions are evaluated at runtime to extract values from packet data.
- * @example { offset: 5, length: 2 } or 'data[5] * 256 + data[6]'
+ * @example { index: 5, length: 2 } or 'data[5] * 256 + data[6]'
  */
 export type StateSchemaOrCEL = StateSchema | string;
 
 /**
  * Numeric state schema that can be either a structured schema object or a CEL expression string.
  * CEL expressions are evaluated at runtime to extract numeric values from packet data.
- * @example { offset: 5, length: 1, precision: 1 } or 'data[5] / 10.0'
+ * @example { index: 5, length: 1, precision: 1 } or 'data[5] / 10.0'
  */
 export type StateNumSchemaOrCEL = StateNumSchema | string;

--- a/packages/core/src/service/command.manager.ts
+++ b/packages/core/src/service/command.manager.ts
@@ -6,6 +6,7 @@ import { logger } from '../utils/logger.js';
 import { PacketProcessor } from '../protocol/packet-processor.js';
 import { StateSchema } from '../protocol/types.js';
 import { matchesPacket } from '../utils/packet-matching.js';
+import { hasExplicitSchemaIndex } from '../protocol/schema-index.js';
 import { eventBus } from './event-bus.js';
 
 interface RetryConfig {
@@ -257,7 +258,7 @@ export class CommandManager {
       // offset이 명시되지 않은 경우에만 headerLen을 baseOffset으로 사용
       // offset이 명시된 경우(0 포함)는 헤더 포함 전체 패킷 기준
       const headerLen = this.config.packet_defaults?.rx_header?.length ?? 0;
-      const baseOffset = job.ackMatch.offset === undefined ? headerLen : 0;
+      const baseOffset = hasExplicitSchemaIndex(job.ackMatch) ? 0 : headerLen;
       const matcher = (packet: Buffer) => {
         if (job.ackMatch && matchesPacket(job.ackMatch, packet, { baseOffset })) {
           callback();

--- a/packages/core/src/utils/packet-analysis.ts
+++ b/packages/core/src/utils/packet-analysis.ts
@@ -23,6 +23,7 @@ import { TextDevice } from '../protocol/devices/text.device.js';
 import { BinarySensorDevice } from '../protocol/devices/binary-sensor.device.js';
 import { toEntityId } from './romanize.js';
 import { matchesPacket } from './packet-matching.js';
+import { hasExplicitSchemaIndex } from '../protocol/schema-index.js';
 import { logger } from './logger.js';
 import type { Device } from '../protocol/device.js';
 
@@ -163,7 +164,7 @@ const matchesPacketTrigger = (
   headerLen: number,
 ) => {
   const match = trigger.match as any;
-  const baseOffset = match?.offset === undefined ? headerLen : 0;
+  const baseOffset = hasExplicitSchemaIndex(match) ? 0 : headerLen;
   return matchesPacket(match, packet, { baseOffset });
 };
 

--- a/packages/core/src/utils/packet-matching.ts
+++ b/packages/core/src/utils/packet-matching.ts
@@ -1,5 +1,6 @@
 import { CelExecutor, CompiledScript } from '../protocol/cel-executor.js';
 import { StateSchema } from '../protocol/types.js';
+import { getSchemaIndex } from '../protocol/schema-index.js';
 
 interface PacketMatchOptions {
   baseOffset?: number;
@@ -18,7 +19,7 @@ export function matchesPacket(
     return false;
   }
   const baseOffset = options.baseOffset ?? 0;
-  const offset = (match.offset ?? 0) + baseOffset;
+  const offset = (getSchemaIndex(match) ?? 0) + baseOffset;
   const hasData = Array.isArray(match.data) && match.data.length > 0;
   let matched = true;
 

--- a/packages/core/static/schema/homenet-bridge.schema.json
+++ b/packages/core/static/schema/homenet-bridge.schema.json
@@ -135,11 +135,15 @@
           }
         }
       },
-      "required": ["serial"],
+      "required": [
+        "serial"
+      ],
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
-  "required": ["homenet_bridge"],
+  "required": [
+    "homenet_bridge"
+  ],
   "additionalProperties": false,
   "definitions": {
     "PacketDefaults": {
@@ -254,23 +258,48 @@
           "type": "number"
         },
         "data_bits": {
-          "enum": [5, 6, 7, 8],
+          "enum": [
+            5,
+            6,
+            7,
+            8
+          ],
           "type": "number"
         },
         "parity": {
-          "enum": ["even", "mark", "none", "odd", "space"],
+          "enum": [
+            "even",
+            "mark",
+            "none",
+            "odd",
+            "space"
+          ],
           "type": "string"
         },
         "stop_bits": {
-          "enum": [1, 1.5, 2],
+          "enum": [
+            1,
+            1.5,
+            2
+          ],
           "type": "number"
         },
         "serial_idle": {
           "description": "Idle timeout in ms to close connection (optional).",
-          "type": ["string", "number"]
+          "type": [
+            "string",
+            "number"
+          ]
         }
       },
-      "required": ["baud_rate", "data_bits", "parity", "path", "portId", "stop_bits"]
+      "required": [
+        "baud_rate",
+        "data_bits",
+        "parity",
+        "path",
+        "portId",
+        "stop_bits"
+      ]
     },
     "DeviceConfig": {
       "type": "object",
@@ -294,7 +323,9 @@
           "type": "string"
         }
       },
-      "required": ["id"]
+      "required": [
+        "id"
+      ]
     },
     "LightEntity": {
       "type": "object",
@@ -325,7 +356,7 @@
           ]
         },
         "state_brightness": {
-          "description": "[Deprecated] Numeric state schema in mireds. Prefer state_color_temp_kelvin.",
+          "description": "Numeric state schema that can be either a structured schema object or a CEL expression string.\nCEL expressions are evaluated at runtime to extract numeric values from packet data.",
           "anyOf": [
             {
               "$ref": "#/definitions/StateNumSchema"
@@ -336,7 +367,7 @@
           ]
         },
         "command_brightness": {
-          "description": "[Deprecated] Command schema in mireds. Prefer command_color_temp_kelvin.",
+          "description": "Command schema that can be either a structured schema object or a CEL expression string.\nCEL expressions are evaluated at runtime to construct the command packet.\nFor commands, the CEL expression often constructs the raw bytes directly.",
           "anyOf": [
             {
               "$ref": "#/definitions/CommandSchema"
@@ -347,7 +378,7 @@
           ]
         },
         "state_color_temp_kelvin": {
-          "description": "Numeric state schema for color temperature in kelvin.",
+          "description": "Numeric state schema that can be either a structured schema object or a CEL expression string.\nCEL expressions are evaluated at runtime to extract numeric values from packet data.",
           "anyOf": [
             {
               "$ref": "#/definitions/StateNumSchema"
@@ -358,7 +389,7 @@
           ]
         },
         "command_color_temp_kelvin": {
-          "description": "Command schema for color temperature in kelvin.",
+          "description": "Command schema that can be either a structured schema object or a CEL expression string.\nCEL expressions are evaluated at runtime to construct the command packet.\nFor commands, the CEL expression often constructs the raw bytes directly.",
           "anyOf": [
             {
               "$ref": "#/definitions/CommandSchema"
@@ -591,6 +622,9 @@
         "discovery_linked_id": {
           "type": "string"
         },
+        "discovery_skip": {
+          "type": "boolean"
+        },
         "optimistic": {
           "type": "boolean"
         },
@@ -606,7 +640,11 @@
           "type": "string"
         }
       },
-      "required": ["id", "name", "state"]
+      "required": [
+        "id",
+        "name",
+        "state"
+      ]
     },
     "StateSchema": {
       "description": "Schema for matching and extracting state from a packet.",
@@ -633,8 +671,12 @@
             }
           ]
         },
+        "index": {
+          "description": "Byte index in the full packet where the state value is located.",
+          "type": "number"
+        },
         "offset": {
-          "description": "Byte offset in the packet payload where the state value is located.",
+          "description": "Legacy alias for `index`.",
           "type": "number"
         },
         "inverted": {
@@ -672,12 +714,22 @@
         },
         "endian": {
           "description": "Byte order (endianness).",
-          "enum": ["big", "little"],
+          "enum": [
+            "big",
+            "little"
+          ],
           "type": "string"
         },
         "decode": {
           "description": "specialized decoding strategy.",
-          "enum": ["add_0x80", "ascii", "bcd", "multiply", "none", "signed_byte_half_degree"],
+          "enum": [
+            "add_0x80",
+            "ascii",
+            "bcd",
+            "multiply",
+            "none",
+            "signed_byte_half_degree"
+          ],
           "type": "string"
         },
         "mapping": {
@@ -686,7 +738,10 @@
           "additionalProperties": false,
           "patternProperties": {
             "^[0-9]+$": {
-              "type": ["string", "number"]
+              "type": [
+                "string",
+                "number"
+              ]
             }
           }
         },
@@ -711,8 +766,12 @@
             }
           ]
         },
+        "index": {
+          "description": "Byte index in the full packet where the state value is located.",
+          "type": "number"
+        },
         "offset": {
-          "description": "Byte offset in the packet payload where the state value is located.",
+          "description": "Legacy alias for `index`.",
           "type": "number"
         },
         "inverted": {
@@ -759,7 +818,14 @@
         },
         "value_encode": {
           "description": "Value encoding/decoding strategies for numeric states.",
-          "enum": ["add_0x80", "ascii", "bcd", "multiply", "none", "signed_byte_half_degree"],
+          "enum": [
+            "add_0x80",
+            "ascii",
+            "bcd",
+            "multiply",
+            "none",
+            "signed_byte_half_degree"
+          ],
           "type": "string"
         },
         "length": {
@@ -769,7 +835,10 @@
           "type": "boolean"
         },
         "endian": {
-          "enum": ["big", "little"],
+          "enum": [
+            "big",
+            "little"
+          ],
           "type": "string"
         },
         "multiply_factor": {
@@ -786,6 +855,16 @@
     "ClimateEntity": {
       "type": "object",
       "properties": {
+        "temperature_unit": {
+          "enum": [
+            "C",
+            "F"
+          ],
+          "type": "string"
+        },
+        "visual": {
+          "$ref": "#/definitions/ClimateVisualOptions"
+        },
         "state": {
           "$ref": "#/definitions/StateSchema"
         },
@@ -1409,6 +1488,9 @@
         "discovery_linked_id": {
           "type": "string"
         },
+        "discovery_skip": {
+          "type": "boolean"
+        },
         "optimistic": {
           "type": "boolean"
         },
@@ -1424,7 +1506,34 @@
           "type": "string"
         }
       },
-      "required": ["id", "name", "state"]
+      "required": [
+        "id",
+        "name",
+        "state"
+      ]
+    },
+    "ClimateVisualOptions": {
+      "type": "object",
+      "properties": {
+        "min_temperature": {
+          "type": [
+            "string",
+            "number"
+          ]
+        },
+        "max_temperature": {
+          "type": [
+            "string",
+            "number"
+          ]
+        },
+        "temperature_step": {
+          "type": [
+            "string",
+            "number"
+          ]
+        }
+      }
     },
     "ValveEntity": {
       "type": "object",
@@ -1557,6 +1666,9 @@
         "discovery_linked_id": {
           "type": "string"
         },
+        "discovery_skip": {
+          "type": "boolean"
+        },
         "optimistic": {
           "type": "boolean"
         },
@@ -1572,7 +1684,11 @@
           "type": "string"
         }
       },
-      "required": ["id", "name", "state"]
+      "required": [
+        "id",
+        "name",
+        "state"
+      ]
     },
     "ButtonEntity": {
       "type": "object",
@@ -1620,6 +1736,9 @@
         "discovery_linked_id": {
           "type": "string"
         },
+        "discovery_skip": {
+          "type": "boolean"
+        },
         "optimistic": {
           "type": "boolean"
         },
@@ -1635,7 +1754,11 @@
           "type": "string"
         }
       },
-      "required": ["command_press", "id", "name"]
+      "required": [
+        "command_press",
+        "id",
+        "name"
+      ]
     },
     "SensorEntity": {
       "type": "object",
@@ -1705,6 +1828,9 @@
         "discovery_linked_id": {
           "type": "string"
         },
+        "discovery_skip": {
+          "type": "boolean"
+        },
         "optimistic": {
           "type": "boolean"
         },
@@ -1720,7 +1846,11 @@
           "type": "string"
         }
       },
-      "required": ["id", "name", "state"]
+      "required": [
+        "id",
+        "name",
+        "state"
+      ]
     },
     "FanEntity": {
       "type": "object",
@@ -1927,6 +2057,9 @@
         "discovery_linked_id": {
           "type": "string"
         },
+        "discovery_skip": {
+          "type": "boolean"
+        },
         "optimistic": {
           "type": "boolean"
         },
@@ -1942,7 +2075,11 @@
           "type": "string"
         }
       },
-      "required": ["id", "name", "state"]
+      "required": [
+        "id",
+        "name",
+        "state"
+      ]
     },
     "SwitchEntity": {
       "type": "object",
@@ -2021,6 +2158,9 @@
         "discovery_linked_id": {
           "type": "string"
         },
+        "discovery_skip": {
+          "type": "boolean"
+        },
         "optimistic": {
           "type": "boolean"
         },
@@ -2036,7 +2176,11 @@
           "type": "string"
         }
       },
-      "required": ["id", "name", "state"]
+      "required": [
+        "id",
+        "name",
+        "state"
+      ]
     },
     "LockEntity": {
       "type": "object",
@@ -2114,6 +2258,9 @@
         "discovery_linked_id": {
           "type": "string"
         },
+        "discovery_skip": {
+          "type": "boolean"
+        },
         "optimistic": {
           "type": "boolean"
         },
@@ -2129,7 +2276,10 @@
           "type": "string"
         }
       },
-      "required": ["id", "name"]
+      "required": [
+        "id",
+        "name"
+      ]
     },
     "NumberEntity": {
       "type": "object",
@@ -2236,6 +2386,9 @@
         "discovery_linked_id": {
           "type": "string"
         },
+        "discovery_skip": {
+          "type": "boolean"
+        },
         "optimistic": {
           "type": "boolean"
         },
@@ -2251,7 +2404,10 @@
           "type": "string"
         }
       },
-      "required": ["id", "name"]
+      "required": [
+        "id",
+        "name"
+      ]
     },
     "SelectEntity": {
       "type": "object",
@@ -2335,6 +2491,9 @@
         "discovery_linked_id": {
           "type": "string"
         },
+        "discovery_skip": {
+          "type": "boolean"
+        },
         "optimistic": {
           "type": "boolean"
         },
@@ -2350,7 +2509,11 @@
           "type": "string"
         }
       },
-      "required": ["id", "name", "options"]
+      "required": [
+        "id",
+        "name",
+        "options"
+      ]
     },
     "SelectCommandSchema": {
       "type": "object",
@@ -2385,7 +2548,14 @@
         },
         "value_encode": {
           "description": "Value encoding/decoding strategies for numeric states.",
-          "enum": ["add_0x80", "ascii", "bcd", "multiply", "none", "signed_byte_half_degree"],
+          "enum": [
+            "add_0x80",
+            "ascii",
+            "bcd",
+            "multiply",
+            "none",
+            "signed_byte_half_degree"
+          ],
           "type": "string"
         },
         "length": {
@@ -2395,7 +2565,10 @@
           "type": "boolean"
         },
         "endian": {
-          "enum": ["big", "little"],
+          "enum": [
+            "big",
+            "little"
+          ],
           "type": "string"
         },
         "multiply_factor": {
@@ -2435,12 +2608,22 @@
         },
         "endian": {
           "description": "Byte order (endianness).",
-          "enum": ["big", "little"],
+          "enum": [
+            "big",
+            "little"
+          ],
           "type": "string"
         },
         "decode": {
           "description": "specialized decoding strategy.",
-          "enum": ["add_0x80", "ascii", "bcd", "multiply", "none", "signed_byte_half_degree"],
+          "enum": [
+            "add_0x80",
+            "ascii",
+            "bcd",
+            "multiply",
+            "none",
+            "signed_byte_half_degree"
+          ],
           "type": "string"
         },
         "mapping": {
@@ -2449,7 +2632,10 @@
           "additionalProperties": false,
           "patternProperties": {
             "^[0-9]+$": {
-              "type": ["string", "number"]
+              "type": [
+                "string",
+                "number"
+              ]
             }
           }
         },
@@ -2474,8 +2660,12 @@
             }
           ]
         },
+        "index": {
+          "description": "Byte index in the full packet where the state value is located.",
+          "type": "number"
+        },
         "offset": {
-          "description": "Byte offset in the packet payload where the state value is located.",
+          "description": "Legacy alias for `index`.",
           "type": "number"
         },
         "inverted": {
@@ -2555,6 +2745,9 @@
         "discovery_linked_id": {
           "type": "string"
         },
+        "discovery_skip": {
+          "type": "boolean"
+        },
         "optimistic": {
           "type": "boolean"
         },
@@ -2570,7 +2763,10 @@
           "type": "string"
         }
       },
-      "required": ["id", "name"]
+      "required": [
+        "id",
+        "name"
+      ]
     },
     "TextEntity": {
       "type": "object",
@@ -2599,7 +2795,10 @@
           "type": "string"
         },
         "mode": {
-          "enum": ["password", "text"],
+          "enum": [
+            "password",
+            "text"
+          ],
           "type": "string"
         },
         "command_text": {
@@ -2667,6 +2866,9 @@
         "discovery_linked_id": {
           "type": "string"
         },
+        "discovery_skip": {
+          "type": "boolean"
+        },
         "optimistic": {
           "type": "boolean"
         },
@@ -2682,7 +2884,10 @@
           "type": "string"
         }
       },
-      "required": ["id", "name"]
+      "required": [
+        "id",
+        "name"
+      ]
     },
     "BinarySensorEntity": {
       "type": "object",
@@ -2752,6 +2957,9 @@
         "discovery_linked_id": {
           "type": "string"
         },
+        "discovery_skip": {
+          "type": "boolean"
+        },
         "optimistic": {
           "type": "boolean"
         },
@@ -2767,7 +2975,11 @@
           "type": "string"
         }
       },
-      "required": ["id", "name", "state"]
+      "required": [
+        "id",
+        "name",
+        "state"
+      ]
     },
     "AutomationConfig": {
       "description": "Configuration for an Automation rule.",
@@ -2786,7 +2998,12 @@
         },
         "mode": {
           "description": "Execution mode when trigger fires while running.\n- `parallel`: Run multiple instances (default).\n- `single`: Ignore new triggers while running.\n- `restart`: Stop current and start new.\n- `queued`: Queue new triggers.",
-          "enum": ["parallel", "queued", "restart", "single"],
+          "enum": [
+            "parallel",
+            "queued",
+            "restart",
+            "single"
+          ],
           "type": "string"
         },
         "trigger": {
@@ -2825,7 +3042,11 @@
           "type": "boolean"
         }
       },
-      "required": ["id", "then", "trigger"]
+      "required": [
+        "id",
+        "then",
+        "trigger"
+      ]
     },
     "AutomationTrigger": {
       "anyOf": [
@@ -2864,18 +3085,27 @@
         },
         "debounce_ms": {
           "description": "Debounce time in ms (or '1s'). Prevents rapid firing.",
-          "type": ["string", "number"]
+          "type": [
+            "string",
+            "number"
+          ]
         },
         "debounce": {
           "description": "Alias for debounce_ms.",
-          "type": ["string", "number"]
+          "type": [
+            "string",
+            "number"
+          ]
         },
         "guard": {
           "description": "Additional CEL condition.",
           "type": "string"
         }
       },
-      "required": ["entity_id", "type"]
+      "required": [
+        "entity_id",
+        "type"
+      ]
     },
     "AutomationTriggerPacket": {
       "description": "Trigger based on receiving a specific raw packet.",
@@ -2887,14 +3117,17 @@
         },
         "match": {
           "$ref": "#/definitions/StateSchema",
-          "description": "Schema to match the received packet.\n`data` field is required. `offset` can be used to skip header."
+          "description": "Schema to match the received packet.\n`data` field is required. `index` can be used to skip header."
         },
         "guard": {
           "description": "Additional CEL condition.",
           "type": "string"
         }
       },
-      "required": ["match", "type"]
+      "required": [
+        "match",
+        "type"
+      ]
     },
     "AutomationTriggerSchedule": {
       "description": "Trigger based on time interval or cron schedule.",
@@ -2906,7 +3139,10 @@
         },
         "every": {
           "description": "Interval string (e.g. '5m', '1h').",
-          "type": ["string", "number"]
+          "type": [
+            "string",
+            "number"
+          ]
         },
         "cron": {
           "description": "Cron expression (e.g. '0 0 * * *').",
@@ -2917,7 +3153,9 @@
           "type": "string"
         }
       },
-      "required": ["type"]
+      "required": [
+        "type"
+      ]
     },
     "AutomationTriggerStartup": {
       "description": "Trigger executed when the bridge starts up.",
@@ -2932,7 +3170,9 @@
           "type": "string"
         }
       },
-      "required": ["type"]
+      "required": [
+        "type"
+      ]
     },
     "AutomationAction": {
       "anyOf": [
@@ -2994,7 +3234,10 @@
           "type": "boolean"
         }
       },
-      "required": ["action", "target"]
+      "required": [
+        "action",
+        "target"
+      ]
     },
     "AutomationActionPublish": {
       "description": "Action to publish an MQTT message.",
@@ -3012,7 +3255,11 @@
           "type": "boolean"
         }
       },
-      "required": ["action", "payload", "topic"]
+      "required": [
+        "action",
+        "payload",
+        "topic"
+      ]
     },
     "AutomationActionLog": {
       "description": "Action to write a log message.",
@@ -3023,14 +3270,23 @@
           "const": "log"
         },
         "level": {
-          "enum": ["debug", "error", "info", "trace", "warn"],
+          "enum": [
+            "debug",
+            "error",
+            "info",
+            "trace",
+            "warn"
+          ],
           "type": "string"
         },
         "message": {
           "type": "string"
         }
       },
-      "required": ["action", "message"]
+      "required": [
+        "action",
+        "message"
+      ]
     },
     "AutomationActionDelay": {
       "description": "Action to pause execution.",
@@ -3042,18 +3298,29 @@
         },
         "milliseconds": {
           "description": "Duration in ms or string (e.g. '1s').",
-          "type": ["string", "number"]
+          "type": [
+            "string",
+            "number"
+          ]
         },
         "duration": {
           "description": "Alias for milliseconds.",
-          "type": ["string", "number"]
+          "type": [
+            "string",
+            "number"
+          ]
         },
         "delay": {
           "description": "Alias for milliseconds.",
-          "type": ["string", "number"]
+          "type": [
+            "string",
+            "number"
+          ]
         }
       },
-      "required": ["action"]
+      "required": [
+        "action"
+      ]
     },
     "AutomationActionScript": {
       "description": "Action to run a named script.",
@@ -3076,7 +3343,9 @@
           "$ref": "#/definitions/Record%3Cstring%2Cany%3E"
         }
       },
-      "required": ["action"]
+      "required": [
+        "action"
+      ]
     },
     "Record<string,any>": {
       "type": "object"
@@ -3096,7 +3365,11 @@
           "$ref": "#/definitions/Record%3Cstring%2Cany%3E"
         }
       },
-      "required": ["action", "state", "target_id"]
+      "required": [
+        "action",
+        "state",
+        "target_id"
+      ]
     },
     "AutomationActionSendPacket": {
       "description": "Action to send a raw packet to the RS485 bus.",
@@ -3171,7 +3444,10 @@
           ]
         }
       },
-      "required": ["action", "data"]
+      "required": [
+        "action",
+        "data"
+      ]
     },
     "AutomationActionIf": {
       "description": "Conditional action (If-Then-Else).",
@@ -3198,7 +3474,11 @@
           }
         }
       },
-      "required": ["action", "condition", "then"]
+      "required": [
+        "action",
+        "condition",
+        "then"
+      ]
     },
     "AutomationActionRepeat": {
       "description": "Loop action.",
@@ -3227,7 +3507,10 @@
           }
         }
       },
-      "required": ["action", "actions"]
+      "required": [
+        "action",
+        "actions"
+      ]
     },
     "AutomationActionWaitUntil": {
       "description": "Action to wait for a condition to become true.",
@@ -3243,14 +3526,23 @@
         },
         "timeout": {
           "description": "Timeout in ms or string (default: 30s).",
-          "type": ["string", "number"]
+          "type": [
+            "string",
+            "number"
+          ]
         },
         "check_interval": {
           "description": "Polling interval (default: 100ms).",
-          "type": ["string", "number"]
+          "type": [
+            "string",
+            "number"
+          ]
         }
       },
-      "required": ["action", "condition"]
+      "required": [
+        "action",
+        "condition"
+      ]
     },
     "AutomationActionChoose": {
       "description": "Switch-like conditional action.\nExecutes the first choice whose condition is true.",
@@ -3274,7 +3566,10 @@
           }
         }
       },
-      "required": ["action", "choices"]
+      "required": [
+        "action",
+        "choices"
+      ]
     },
     "AutomationActionChooseChoice": {
       "type": "object",
@@ -3290,7 +3585,10 @@
           }
         }
       },
-      "required": ["condition", "then"]
+      "required": [
+        "condition",
+        "then"
+      ]
     },
     "AutomationActionStop": {
       "description": "Action to stop the current automation execution.",
@@ -3305,7 +3603,9 @@
           "type": "string"
         }
       },
-      "required": ["action"]
+      "required": [
+        "action"
+      ]
     },
     "ScriptConfig": {
       "description": "Reusable script configuration.",
@@ -3328,7 +3628,10 @@
           "$ref": "#/definitions/Record%3Cstring%2CScriptArg%3E"
         }
       },
-      "required": ["actions", "id"]
+      "required": [
+        "actions",
+        "id"
+      ]
     },
     "Record<string,ScriptArg>": {
       "type": "object"

--- a/packages/core/test/config_leniency.test.ts
+++ b/packages/core/test/config_leniency.test.ts
@@ -73,4 +73,41 @@ describe('Config Leniency', () => {
     expect(config.text_sensor[0].state_text).toBeDefined();
     expect(config.text_sensor[0].state_text.offset).toBe(4);
   });
+
+  it('should copy index to offset for schema compatibility', () => {
+    const config: any = {
+      serial: { portId: 'test', path: '/dev/test', baud_rate: 9600 },
+      sensor: [
+        {
+          id: 'test_sensor_index',
+          state: { data: [0x05], index: 0 },
+          state_number: { index: 3, length: 1 },
+        },
+      ],
+    };
+
+    normalizeConfig(config);
+
+    expect(config.sensor[0].state.index).toBe(0);
+    expect(config.sensor[0].state.offset).toBe(0);
+    expect(config.sensor[0].state_number.index).toBe(3);
+    expect(config.sensor[0].state_number.offset).toBe(3);
+  });
+
+  it('should copy offset to index for renamed field', () => {
+    const config: any = {
+      serial: { portId: 'test', path: '/dev/test', baud_rate: 9600 },
+      sensor: [
+        {
+          id: 'test_sensor_offset_alias',
+          state: { data: [0x06], offset: 1 },
+        },
+      ],
+    };
+
+    normalizeConfig(config);
+
+    expect(config.sensor[0].state.offset).toBe(1);
+    expect(config.sensor[0].state.index).toBe(1);
+  });
 });

--- a/packages/core/test/packet-matching.test.ts
+++ b/packages/core/test/packet-matching.test.ts
@@ -38,4 +38,14 @@ describe('matchesPacket', () => {
     };
     expect(matchesPacket(schema, Buffer.from([0x01, 0x02]))).toBe(false);
   });
+
+  it('should support index field as primary position key', () => {
+    const schema: StateSchema = {
+      index: 1,
+      data: [0xaa, 0xbb],
+    };
+
+    expect(matchesPacket(schema, Buffer.from([0x00, 0xaa, 0xbb]))).toBe(true);
+    expect(matchesPacket(schema, Buffer.from([0xaa, 0xbb, 0x00]))).toBe(false);
+  });
 });


### PR DESCRIPTION
### Motivation
- 설정에서 바이트 위치를 가리키는 이름을 `offset` 대신 의미상 더 적절한 `index`로 표준화하려는 목적입니다.
- 기존 사용자 설정의 호환성을 위해 `offset`을 레거시 alias로 계속 허용해야 합니다.
- 런타임에서 매칭/추출/ACK 판정 로직들이 `offset` 기반으로 흩어져 있어 이를 `index` 우선 해석으로 통일할 필요가 있었습니다.

### Description
- `StateSchema`에 `index?: number` 필드를 추가하고 `offset`은 레거시 alias로 유지하도록 타입과 주석을 갱신했습니다 (`packages/core/src/protocol/types.ts`).
- `getSchemaIndex` / `hasExplicitSchemaIndex` 유틸을 추가해 `index` 우선, `offset`을 폴백으로 해석하도록 중앙화된 로직을 도입했습니다 (`packages/core/src/protocol/schema-index.ts`).
- 런타임 핵심 경로에서 `index` 기반 해석을 사용하도록 변경했습니다: 패킷 매칭/값 추출/디바이스 매칭/ACK 리스너/자동화의 `update_state` 등 (`schema-utils.ts`, `packet-matching.ts`, `device.ts`, `generic.device.ts`, `state-normalizer.ts`, `command.manager.ts`, `automation-manager.ts`, `packet-analysis.ts`, `text*.device.ts` 등).
- 설정 정규화 단계에서 `index <-> offset` 양방향 보정을 재귀적으로 적용해 신규 `index` 또는 기존 `offset` 모두 허용하도록 했습니다 (`packages/core/src/config/index.ts`).
- 문서(`docs/config/schemas.md`)와 JSON 스키마(`packages/core/static/schema/homenet-bridge.schema.json`)를 `index` 중심으로 업데이트하고 관련 테스트를 추가/수정했습니다 (`packages/core/test/*`).

### Testing
- 실행한 명령: `pnpm format`, `pnpm build`, `pnpm lint`, `pnpm test`.
- `pnpm format`: 성공했습니다.
- `pnpm build`: 성공했습니다 (UI 빌드에서 기존 Svelte unused-CSS 경고가 존재하지만 빌드 실패는 아님).
- `pnpm lint`: 성공(경고 3건: Svelte unused CSS; 실패는 아니었습니다).
- `pnpm test` (Vitest, 워크스페이스 전체): 모든 테스트가 통과했습니다 (core/service/simulator 등 관련 패키지 테스트 성공).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d70398a044832cbbb894fc2de6806c)