### PR TITLE
fix(core): 정규화 후 `offset` 필드 제거

### DIFF
--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -50,10 +50,11 @@ function normalizeIndexAlias(value: unknown): void {
   }
 
   const obj = value as Record<string, unknown>;
-  if (typeof obj.index === 'number' && obj.offset === undefined) {
-    obj.offset = obj.index;
-  } else if (typeof obj.offset === 'number' && obj.index === undefined) {
+  if (typeof obj.offset === 'number' && obj.index === undefined) {
     obj.index = obj.offset;
+  }
+  if (Object.hasOwn(obj, 'offset')) {
+    delete obj.offset;
   }
 
   Object.values(obj).forEach((child) => normalizeIndexAlias(child));

--- a/packages/core/test/config_leniency.test.ts
+++ b/packages/core/test/config_leniency.test.ts
@@ -17,7 +17,8 @@ describe('Config Leniency', () => {
     normalizeConfig(config);
 
     expect(config.sensor[0].state_number).toBeDefined();
-    expect(config.sensor[0].state_number.offset).toBe(1);
+    expect(config.sensor[0].state_number.index).toBe(1);
+    expect(config.sensor[0].state_number.offset).toBeUndefined();
   });
 
   it('should treat state_value as state_text for text_sensor', () => {
@@ -35,7 +36,8 @@ describe('Config Leniency', () => {
     normalizeConfig(config);
 
     expect(config.text_sensor[0].state_text).toBeDefined();
-    expect(config.text_sensor[0].state_text.offset).toBe(2);
+    expect(config.text_sensor[0].state_text.index).toBe(2);
+    expect(config.text_sensor[0].state_text.offset).toBeUndefined();
   });
 
   it('should treat state_value as state_number for sensor', () => {
@@ -53,7 +55,8 @@ describe('Config Leniency', () => {
     normalizeConfig(config);
 
     expect(config.sensor[0].state_number).toBeDefined();
-    expect(config.sensor[0].state_number.offset).toBe(3);
+    expect(config.sensor[0].state_number.index).toBe(3);
+    expect(config.sensor[0].state_number.offset).toBeUndefined();
   });
 
   it('should treat state_number as state_text for text_sensor', () => {
@@ -71,10 +74,11 @@ describe('Config Leniency', () => {
     normalizeConfig(config);
 
     expect(config.text_sensor[0].state_text).toBeDefined();
-    expect(config.text_sensor[0].state_text.offset).toBe(4);
+    expect(config.text_sensor[0].state_text.index).toBe(4);
+    expect(config.text_sensor[0].state_text.offset).toBeUndefined();
   });
 
-  it('should copy index to offset for schema compatibility', () => {
+  it('should keep index and remove offset after normalization', () => {
     const config: any = {
       serial: { portId: 'test', path: '/dev/test', baud_rate: 9600 },
       sensor: [
@@ -89,12 +93,12 @@ describe('Config Leniency', () => {
     normalizeConfig(config);
 
     expect(config.sensor[0].state.index).toBe(0);
-    expect(config.sensor[0].state.offset).toBe(0);
+    expect(config.sensor[0].state.offset).toBeUndefined();
     expect(config.sensor[0].state_number.index).toBe(3);
-    expect(config.sensor[0].state_number.offset).toBe(3);
+    expect(config.sensor[0].state_number.offset).toBeUndefined();
   });
 
-  it('should copy offset to index for renamed field', () => {
+  it('should rename offset to index and remove offset', () => {
     const config: any = {
       serial: { portId: 'test', path: '/dev/test', baud_rate: 9600 },
       sensor: [
@@ -107,7 +111,7 @@ describe('Config Leniency', () => {
 
     normalizeConfig(config);
 
-    expect(config.sensor[0].state.offset).toBe(1);
     expect(config.sensor[0].state.index).toBe(1);
+    expect(config.sensor[0].state.offset).toBeUndefined();
   });
 });


### PR DESCRIPTION
### Motivation
- YAML 정규화 과정에서 `index`와 `offset`이 동시에 남아 직렬화 시 중복 필드가 생성되는 문제를 해결하기 위해 내부 표현을 `index`로 일원화하고 `offset`을 제거합니다.

### Description
- `normalizeIndexAlias`를 변경해 `offset`이 존재하면 `index`로 복사하고 이후 `offset` 키를 삭제하도록 구현했습니다 (`packages/core/src/config/index.ts`).
- 관련 테스트 `packages/core/test/config_leniency.test.ts`를 수정해 정규화 후 `index`가 유지되고 `offset`은 제거되는 동작을 검증하도록 업데이트했습니다.
- 변경 후 코드 스타일 정리를 위해 `pnpm format`을 실행했습니다.

### Testing
- `pnpm build`를 실행했고 빌드는 성공했습니다.
- `pnpm lint`를 실행했고 에러 없이 완료되었으며 기존 Svelte CSS 경고가 표시되었지만 실패는 아니었습니다.
- `pnpm test`를 실행했고 모든 테스트가 통과하여 성공했습니다.
- 최종적으로 `pnpm format`을 실행해 포맷을 적용했습니다.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7ba4430e0832cb9689e83243bd045)