### PR TITLE
feat(gallery): 현대 이마주 전열교환기 모드 스니펫 추가

### DIFF
--- a/gallery/hyundai_imazu/fan_modes.yaml
+++ b/gallery/hyundai_imazu/fan_modes.yaml
@@ -1,0 +1,73 @@
+meta:
+  name: "전열교환기 모드 설정"
+  name_en: "Heat Exchanger Fan Modes"
+  description: "현대 이마주 전열교환기 설정입니다. 전열/자동/바이패스/취침 프리셋과 속도 제어를 지원합니다."
+  description_en: "Hyundai Imazu heat-exchanger fan configuration with ventilation/auto/bypass/sleep presets and speed control."
+  version: "1.0.0"
+  author: "Qualified4"
+  tags: ["fan", "ventilation", "hyundai", "imazu", "preset"]
+
+discovery:
+  match:
+    data: [0x0E, 0x01, 0x2B, 0x04, 0x40, 0x11]
+    mask: [0x0F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
+
+entities:
+  fan:
+    - name: "전열교환기"
+      id: "room_1_fan_1"
+      state:
+        data: [0x0E, 0x01, 0x2B, 0x04, 0x40, 0x11]
+        mask: [0x0F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
+      state_on:
+        data: [0x01]
+        mask: [0xFF]
+        index: 9
+      state_off:
+        data: [0x00]
+        mask: [0xFF]
+        index: 9
+      state_speed:
+        mask: 255
+        mapping:
+          "0": 0
+          "1": 33
+          "3": 66
+          "7": 100
+        index: 9
+      preset_modes:
+        - "전열"
+        - "자동"
+        - "바이패스"
+        - "취침"
+      state_preset_mode: >-
+        data[8] == 0x01 ? "전열" :
+        (data[8] == 0x03 ? "자동" :
+        (data[8] == 0x81 ? "바이패스" :
+        (data[8] == 0x06 ? "취침" : "off")))
+      command_on: |-
+        [
+          [0x0B, 0x01, 0x2B, 0x02, 0x40, 0x11, 0x03, 0x00]
+        ]
+      command_off: |-
+        [
+          [0x0B, 0x01, 0x2B, 0x02, 0x40, 0x11, 0x02, 0x00]
+        ]
+      command_speed: |-
+        [
+          [0x0B, 0x01, 0x2B, 0x02, 0x42, 0x11,
+            get_from_state('preset_mode', 'off') == "off" ? 0x00 :
+              (x <= 34 ? 0x01 :
+                (x <= 67 ? 0x03 : 0x07)
+              ),
+          0x00]
+        ]
+      command_preset_mode: |-
+        [
+          [0x0B, 0x01, 0x2B, 0x02, 0x40, 0x11,
+            xstr == "전열" ? 0x01 :
+              (xstr == "바이패스" ? 0x81 :
+                (xstr == "취침" ? 0x06 : 0x03)
+              ),
+          0x00]
+        ]

--- a/gallery/list.json
+++ b/gallery/list.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-10T03:06:10.729Z",
+  "generated_at": "2026-04-13T07:10:42.876Z",
   "vendors": [
     {
       "id": "bestin",
@@ -787,6 +787,30 @@
               "fan": 1
             },
             "automations": 1,
+            "scripts": 0
+          }
+        },
+        {
+          "file": "hyundai_imazu/fan_modes.yaml",
+          "name": "전열교환기 모드 설정",
+          "name_en": "Heat Exchanger Fan Modes",
+          "description": "현대 이마주 전열교환기 설정입니다. 전열/자동/바이패스/취침 프리셋과 속도 제어를 지원합니다.",
+          "description_en": "Hyundai Imazu heat-exchanger fan configuration with ventilation/auto/bypass/sleep presets and speed control.",
+          "version": "1.0.0",
+          "author": "Qualified4",
+          "tags": [
+            "fan",
+            "ventilation",
+            "hyundai",
+            "imazu",
+            "preset"
+          ],
+          "parameters": [],
+          "content_summary": {
+            "entities": {
+              "fan": 1
+            },
+            "automations": 0,
             "scripts": 0
           }
         },

--- a/gallery/list_new.json
+++ b/gallery/list_new.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-10T03:06:10.730Z",
+  "generated_at": "2026-04-13T07:10:42.864Z",
   "vendors": [
     {
       "id": "bestin",
@@ -2216,6 +2216,50 @@
                 255,
                 255,
                 253,
+                255
+              ]
+            }
+          }
+        },
+        {
+          "file": "hyundai_imazu/fan_modes.yaml",
+          "name": "전열교환기 모드 설정",
+          "name_en": "Heat Exchanger Fan Modes",
+          "description": "현대 이마주 전열교환기 설정입니다. 전열/자동/바이패스/취침 프리셋과 속도 제어를 지원합니다.",
+          "description_en": "Hyundai Imazu heat-exchanger fan configuration with ventilation/auto/bypass/sleep presets and speed control.",
+          "version": "1.0.0",
+          "author": "Qualified4",
+          "tags": [
+            "fan",
+            "ventilation",
+            "hyundai",
+            "imazu",
+            "preset"
+          ],
+          "parameters": [],
+          "content_summary": {
+            "entities": {
+              "fan": 1
+            },
+            "automations": 0,
+            "scripts": 0
+          },
+          "discovery": {
+            "match": {
+              "data": [
+                14,
+                1,
+                43,
+                4,
+                64,
+                17
+              ],
+              "mask": [
+                15,
+                255,
+                255,
+                255,
+                255,
                 255
               ]
             }


### PR DESCRIPTION
### Motivation
- Discussion #636에서 제안된 현대 이마주 전열교환기(heat-exchanger) 설정을 갤러리에 추가해 사용자에게 프리셋 기반 모드 및 속도 제어 스니펫을 제공하려는 목적입니다.

### Description
- 새 갤러리 스니펫 파일 `gallery/hyundai_imazu/fan_modes.yaml`를 추가하여 전원(on/off), 속도(33/66/100), 프리셋(전열/자동/바이패스/취침) 및 제어 로직을 포함했습니다.
- 갤러리 인덱스 파일인 `gallery/list_new.json`과 레거시 `gallery/list.json`에 해당 스니펫의 메타데이터·요약·(가능한 경우)discovery 정보를 반영해 목록 노출을 갱신했습니다.
- 파일 포맷팅을 적용했고 추가된 스니펫은 기존 갤러리 구조 및 검색 규칙과 일관되게 배치했습니다.

### Testing
- `pnpm format`를 실행해 코드 스타일을 적용했고 성공했습니다.
- `pnpm build`를 실행해 관련 패키지(`@rs485-homenet/core`, `@rs485-homenet/service`, `@rs485-homenet/ui`) 빌드가 정상 완료되었습니다.
- `pnpm lint`를 실행해 린트 검사 통과(에러/경고 없음)했습니다.
- `pnpm test`를 실행해 저장소의 자동화 테스트가 성공적으로 통과했습니다.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc9657bb3c832ca72e3d2dee10f2d6)