### PR TITLE
feat(core): MQTT 연결 상태 전이 로그 추가

### DIFF
--- a/packages/core/src/service/bridge.service.ts
+++ b/packages/core/src/service/bridge.service.ts
@@ -687,10 +687,20 @@ export class HomeNetBridge extends EventEmitter {
       eventBus.emit('mqtt:status', { state, portId: mqttPortId });
     };
 
-    this.client.on('connect', () => emitMqttStatus('connected'));
-    this.client.on('reconnect', () => emitMqttStatus('connecting'));
-    this.client.on('offline', () => emitMqttStatus('connecting'));
+    this.client.on('connect', () => {
+      logger.info({ portId: mqttPortId }, '[core] MQTT connected');
+      emitMqttStatus('connected');
+    });
+    this.client.on('reconnect', () => {
+      logger.warn({ portId: mqttPortId }, '[core] MQTT reconnecting');
+      emitMqttStatus('connecting');
+    });
+    this.client.on('offline', () => {
+      logger.warn({ portId: mqttPortId }, '[core] MQTT offline');
+      emitMqttStatus('connecting');
+    });
     this.client.on('close', () => {
+      logger.warn({ portId: mqttPortId }, '[core] MQTT connection closed');
       eventBus.emit('mqtt:disconnected', { portId: mqttPortId });
       emitMqttStatus('disconnected');
     });


### PR DESCRIPTION
### Motivation

- Home Assistant에서 엔티티가 `unavailable`으로 바뀔 때 애드온 로그만으로는 MQTT 연결 전환 시점을 파악하기 어려워 원인 추적이 힘들었습니다.
- MQTT 클라이언트의 주요 라이프사이클 이벤트(`connect`/`reconnect`/`offline`/`close`)를 애드온 로그에 남겨 관측성을 높이기 위해 변경했습니다.

### Description

- `packages/core/src/service/bridge.service.ts`에 MQTT 이벤트 핸들러 내부에 명시적 로깅을 추가하여 `connect`에서 `logger.info`, `reconnect`/`offline`/`close`에서 `logger.warn`을 출력하도록 했습니다.
- 기존대로 이벤트 버스 전파(`mqtt:status`, `mqtt:disconnected`, `mqtt:error`) 동작은 유지하여 외부 동작에는 영향이 없도록 했습니다.
- 로그 메시지에 포트 식별(`portId`)을 포함하여 어떤 브리지 인스턴스에서 발생했는지 즉시 확인할 수 있게 했습니다.

### Testing

- 코드 포맷터 실행: `pnpm format` 성공했습니다.
- 빌드: `pnpm build` 성공했습니다.
- 타입체크/린트: `pnpm lint` 성공했습니다.
- 단위/통합 테스트: `pnpm test`로 전체 테스트 스위트 실행했고 모든 테스트가 성공적으로 통과했습니다.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eebc4a4b00832cb75c38660eea3aac)