### PR TITLE
core: 패킷 단위 로그 레벨을 debug → trace로 하향

### DIFF
--- a/packages/core/src/protocol/protocol-manager.ts
+++ b/packages/core/src/protocol/protocol-manager.ts
@@ -228,11 +228,11 @@ export class ProtocolManager extends EventEmitter {
 
     let matchedAny = false;
 
-    // Optimization: Only generate hex string if debug logging is enabled
+    // Optimization: Only generate hex string if trace logging is enabled
     // This avoids expensive string allocation/regex ops in the hot path
-    const isDebug = logger.isLevelEnabled('debug');
+    const isTrace = logger.isLevelEnabled('trace');
     let packetHex = '';
-    if (isDebug) {
+    if (isTrace) {
       const parts = new Array(packet.length);
       for (let i = 0; i < packet.length; i++) {
         parts[i] = HEX_STRINGS[packet[i]];
@@ -263,16 +263,16 @@ export class ProtocolManager extends EventEmitter {
         let targetDeviceId = device.getId();
         if (device.config.state_proxy && device.config.target_id) {
           targetDeviceId = device.config.target_id;
-          if (isDebug) {
-            logger.debug(
+          if (isTrace) {
+            logger.trace(
               `[ProtocolManager] Proxying state from ${device.getId()} to ${targetDeviceId}`,
             );
           }
         }
 
-        if (isDebug) {
+        if (isTrace) {
           const stateStr = JSON.stringify(stateUpdates).replace(/["{}]/g, '').replace(/,/g, ', ');
-          logger.debug(
+          logger.trace(
             `[ProtocolManager] ${targetDeviceId} (${device.getName()}): ${packetHex} → {${stateStr}}`,
           );
         }
@@ -287,8 +287,8 @@ export class ProtocolManager extends EventEmitter {
 
     if (!matchedAny) {
       this.emit('unmatched-packet', { packet });
-      if (isDebug) {
-        logger.debug(`[ProtocolManager] Packet not matched: ${packetHex}`);
+      if (isTrace) {
+        logger.trace(`[ProtocolManager] Packet not matched: ${packetHex}`);
       }
     }
   }

--- a/packages/core/src/state/state-manager.ts
+++ b/packages/core/src/state/state-manager.ts
@@ -180,8 +180,8 @@ export class StateManager {
 
     // If no changes detected and we already have state, skip processing
     if (!hasChanges && Object.keys(currentState).length > 0) {
-      if (logger.isLevelEnabled('debug')) {
-        logger.debug(`[StateManager] ${deviceId}: [unchanged]`);
+      if (logger.isLevelEnabled('trace')) {
+        logger.trace(`[StateManager] ${deviceId}: [unchanged]`);
       }
       return;
     }
@@ -229,9 +229,9 @@ export class StateManager {
       });
       eventBus.emit(`device:${deviceId}:state:changed`, newState);
     } else {
-      if (logger.isLevelEnabled('debug')) {
+      if (logger.isLevelEnabled('trace')) {
         const stateStr = payload.replace(/["{}]/g, '').replace(/,/g, ', ');
-        logger.debug(`[StateManager] ${deviceId}: {${stateStr}} [unchanged]`);
+        logger.trace(`[StateManager] ${deviceId}: {${stateStr}} [unchanged]`);
       }
     }
   }


### PR DESCRIPTION
### Motivation
- 패킷마다 반복 출력되는 상세 로그가 디버그 레벨에서 너무 많은 노이즈를 발생시켜 기본 디버그 환경에서 로그가 산만해지는 문제를 해결하기 위해 변경했습니다.

### Description
- `ProtocolManager`의 패킷 매칭/파싱 결과 및 미매칭 출력 레벨을 `debug`에서 `trace`로 변경하고, 패킷 hex 문자열 생성 조건을 `debug` 기준에서 `trace` 기준으로 낮춰 hot path의 불필요한 문자열 연산을 제거했습니다.
- `StateManager`에서 자주 발생하는 `[unchanged]` 관련 로그 두 곳을 `debug`에서 `trace`로 변경해 반복 로그 노이즈를 줄였습니다.
- 변경 파일: `packages/core/src/protocol/protocol-manager.ts`, `packages/core/src/state/state-manager.ts`.

### Testing
- 코드 정렬 및 포맷은 `pnpm format`으로 실행했고 성공했습니다.
- 빌드는 `pnpm build`로 실행했고 성공했습니다.
- 정적 검사(타입체크 등)는 `pnpm lint`로 실행했고 성공했습니다.
- 단위/통합 테스트는 `pnpm test`로 실행했고 모든 테스트가 성공했습니다.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eee5d0ff00832c9e2ff13995f6f173)