### PR TITLE
⚡ [performance] Implement caching in analyzePacketChunk

### DIFF
--- a/packages/core/src/protocol/device.ts
+++ b/packages/core/src/protocol/device.ts
@@ -98,6 +98,11 @@ export abstract class Device {
     this.state = { ...this.state, ...newState };
   }
 
+  public reset(): void {
+    this.state = {};
+    this.lastError = null;
+  }
+
   // Helper to extract data based on schema
   protected extractFromSchema(packet: Buffer, schema: StateSchema | StateNumSchema): any {
     return extractFromSchema(packet, schema);

--- a/packages/core/src/protocol/packet-parser.ts
+++ b/packages/core/src/protocol/packet-parser.ts
@@ -208,6 +208,14 @@ export class PacketParser {
   }
 
   /**
+   * Resets the internal buffer and parsing state.
+   */
+  public reset(): void {
+    this.resetBuffer();
+    this.lastRxTime = 0;
+  }
+
+  /**
    * Processes a chunk of incoming data and returns any complete packets found.
    *
    * The method appends the chunk to the internal buffer and attempts to extract packets

--- a/packages/core/src/utils/packet-analysis.ts
+++ b/packages/core/src/utils/packet-analysis.ts
@@ -116,17 +116,18 @@ const buildDevices = (config: HomenetBridgeConfig) => {
     const entities = config[type] as EntityConfig[] | undefined;
     if (!entities) continue;
     for (const entity of entities) {
-      if (!entity.id && entity.name) {
-        entity.id = toEntityId(entity.name);
-        logger.debug(`[PacketAnalyzer] Generated ID for ${type}: ${entity.name} -> ${entity.id}`);
+      const entityCopy = { ...entity };
+      if (!entityCopy.id && entityCopy.name) {
+        entityCopy.id = toEntityId(entityCopy.name);
+        logger.debug(`[PacketAnalyzer] Generated ID for ${type}: ${entityCopy.name} -> ${entityCopy.id}`);
       }
       const DeviceClass = deviceMap[type] ?? GenericDevice;
-      const device = new DeviceClass(entity, protocolConfig);
+      const device = new DeviceClass(entityCopy, protocolConfig);
       devices.push(device);
-      if (entity.id) {
-        entityMeta.set(entity.id, {
-          id: entity.id,
-          name: entity.name ?? entity.id,
+      if (entityCopy.id) {
+        entityMeta.set(entityCopy.id, {
+          id: entityCopy.id,
+          name: entityCopy.name ?? entityCopy.id,
           type: type.toString(),
         });
       }
@@ -168,12 +169,33 @@ const matchesPacketTrigger = (
   return matchesPacket(match, packet, { baseOffset });
 };
 
+type CachedAnalyzer = {
+  devices: Device[];
+  entityMeta: Map<string, EntityMeta>;
+  parser: PacketParser;
+};
+
+const analyzerCache = new WeakMap<HomenetBridgeConfig, CachedAnalyzer>();
+
 export const analyzePacketChunk = (
   config: HomenetBridgeConfig,
   chunk: Buffer,
 ): PacketAnalysisResult => {
-  const { devices, entityMeta } = buildDevices(config);
-  const parser = new PacketParser(config.packet_defaults || {});
+  let { devices, entityMeta, parser } = analyzerCache.get(config) ?? {};
+
+  if (!devices || !entityMeta || !parser) {
+    const built = buildDevices(config);
+    devices = built.devices;
+    entityMeta = built.entityMeta;
+    parser = new PacketParser(config.packet_defaults || {});
+    analyzerCache.set(config, { devices, entityMeta, parser });
+  } else {
+    parser.reset();
+    for (const device of devices) {
+      device.reset();
+    }
+  }
+
   const packets = parser.parseChunk(chunk);
 
   const automationList = (config.automation || []).filter(


### PR DESCRIPTION
`analyzePacketChunk` 함수에서 매 호출마다 모든 장치(`Device`)와 패킷 파서(`PacketParser`)를 새로 생성하던 비효율성을 개선했습니다.

주요 변경 사항:
1. **`PacketParser` 및 `Device`에 `reset()` 메서드 추가**: 객체를 새로 생성하지 않고 내부 상태만 초기화하여 재사용할 수 있도록 했습니다.
2. **`analyzePacketChunk` 캐싱 구현**: `WeakMap`을 사용하여 `HomenetBridgeConfig` 객체별로 파서와 장치 인스턴스를 캐싱합니다. 이를 통해 반복적인 호출 시 객체 생성 오버헤드와 가비지 컬렉션(GC) 부하를 크게 줄였습니다.
3. **설정 변조 방지**: `buildDevices`에서 엔티티 ID를 생성할 때 원본 설정을 직접 수정하던 버그를 수정하여 부수 효과를 제거했습니다.

이 최적화는 특히 많은 수의 패킷을 분석할 때 시스템의 반응성을 높이고 CPU 사용량을 줄이는 데 기여합니다.

---
*PR created automatically by Jules for task [15309631847420227158](https://jules.google.com/task/15309631847420227158) started by @wooooooooooook*