### PR TITLE
Add match hint and clarify Packet Dictionary labels and translations

### DIFF
--- a/packages/ui/src/lib/components/PacketDictionaryView.svelte
+++ b/packages/ui/src/lib/components/PacketDictionaryView.svelte
@@ -146,6 +146,7 @@
   </div>
 
   <p class="description">{$t('analysis.packet_dictionary.desc')}</p>
+  <p class="description-hint">{$t('analysis.packet_dictionary.match_hint')}</p>
 
   {#if data}
     <div class="stats-bar">
@@ -315,6 +316,13 @@
   .description {
     color: var(--text-secondary);
     font-size: 0.85rem;
+    margin-bottom: 1rem;
+  }
+
+  .description-hint {
+    color: #94a3b8;
+    font-size: 0.8rem;
+    margin-top: -0.5rem;
     margin-bottom: 1rem;
   }
 

--- a/packages/ui/src/lib/i18n/locales/en.json
+++ b/packages/ui/src/lib/i18n/locales/en.json
@@ -312,8 +312,8 @@
     },
     "packet_dictionary": {
       "title": "Packet Dictionary",
-      "desc": "View all packets collected by the bridge. 'Matched' packets are matched to entities, 'Unmatched' packets are valid but not matched to any entity.",
-      "parsed_count": "Matched: {count}",
+      "desc": "View all packets collected by the bridge. 'Matched' means parsed packets (state parsing + command logs), while 'Unmatched' are valid packets not linked to any item.",
+      "parsed_count": "Matched (parsed/command): {count}",
       "unmatched_count": "Unmatched: {count}",
       "tab_all": "All",
       "tab_parsed": "Matched",
@@ -321,7 +321,8 @@
       "empty": "No packets collected yet.",
       "sort_asc": "Sort A-Z",
       "sort_desc": "Sort Z-A",
-      "search_placeholder": "Search packet hex or entity name"
+      "search_placeholder": "Search packet hex, entity ID, or command",
+      "match_hint": "The → labels may include both state-matched entities and command-send logs."
     },
     "stats": {
       "title": "Packet Interval Analysis",

--- a/packages/ui/src/lib/i18n/locales/ko.json
+++ b/packages/ui/src/lib/i18n/locales/ko.json
@@ -312,8 +312,8 @@
     },
     "packet_dictionary": {
       "title": "패킷 딕셔너리",
-      "desc": "브릿지에서 수집한 모든 패킷을 확인합니다. '매칭됨' 패킷은 엔티티와 매칭된 패킷이고, '미매칭'은 유효하지만 매칭되지 않은 패킷입니다.",
-      "parsed_count": "매칭됨: {count}",
+      "desc": "브릿지에서 수집한 모든 패킷을 확인합니다. '매칭됨'은 파싱된 패킷(상태 파싱 + 명령 로그 포함), '미매칭'은 유효하지만 어떤 항목과도 연결되지 않은 패킷입니다.",
+      "parsed_count": "매칭됨(파싱/명령): {count}",
       "unmatched_count": "미매칭: {count}",
       "tab_all": "전체",
       "tab_parsed": "매칭됨",
@@ -321,7 +321,8 @@
       "empty": "아직 수집된 패킷이 없습니다.",
       "sort_asc": "오름차순 정렬",
       "sort_desc": "내림차순 정렬",
-      "search_placeholder": "패킷 HEX 또는 엔티티 이름 검색"
+      "search_placeholder": "패킷 HEX, 엔티티 ID, 명령명 검색",
+      "match_hint": "→ 표시에는 상태 매칭 엔티티와 명령 전송 로그가 함께 표시될 수 있습니다."
     },
     "stats": {
       "title": "패킷 간격 분석",


### PR DESCRIPTION
### Motivation
- Clarify the Packet Dictionary UI text to better communicate what "matched" vs "unmatched" means and indicate that match labels may include command-send logs as well as state matches.

### Description
- Add a hint paragraph in `PacketDictionaryView.svelte` using the `analysis.packet_dictionary.match_hint` i18n key and render it as a `.description-hint` element.
- Add `.description-hint` CSS rules to control color, font-size, and spacing for the new hint text.
- Update English and Korean i18n files (`en.json` and `ko.json`) to reword `packet_dictionary.desc`, change `parsed_count` to `Matched (parsed/command): {count}`, broaden `search_placeholder`, and add the new `match_hint` entries.

### Testing
- No automated tests were added or executed for this copy/style-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe2892690832caeef0150a158954f)