### PR TITLE
🔒 [security] Fix Path Traversal in Config and Schema APIs

### DIFF
--- a/packages/service/src/routes/config-editor.routes.ts
+++ b/packages/service/src/routes/config-editor.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import path from 'node:path';
 import fs from 'node:fs/promises';
+import { resolveSecurePath } from '../utils/helpers.js';
 import yaml from 'js-yaml';
 import type { ConfigEditorService } from '../services/config-editor.service.js';
 
@@ -34,8 +35,8 @@ export function createConfigEditorRoutes(ctx: ConfigEditorRoutesContext): Router
         return res.status(400).json({ error: 'INVALID_FILENAME' });
       }
 
-      const filePath = path.join(configDir, filename);
-      if (!(await fileExists(filePath))) {
+      const filePath = resolveSecurePath(configDir, filename);
+      if (!filePath || !(await fileExists(filePath))) {
         return res.status(404).json({ error: 'FILE_NOT_FOUND' });
       }
 
@@ -69,8 +70,8 @@ export function createConfigEditorRoutes(ctx: ConfigEditorRoutesContext): Router
         return res.status(400).json({ error: 'CONTENT_REQUIRED' });
       }
 
-      const filePath = path.join(configDir, filename);
-      if (!(await fileExists(filePath))) {
+      const filePath = resolveSecurePath(configDir, filename);
+      if (!filePath || !(await fileExists(filePath))) {
         return res.status(404).json({ error: 'FILE_NOT_FOUND' });
       }
 
@@ -137,8 +138,8 @@ export function createConfigEditorRoutes(ctx: ConfigEditorRoutesContext): Router
         return res.status(400).json({ error: 'INVALID_FILENAME' });
       }
 
-      const filePath = path.join(configDir, filename);
-      if (!(await fileExists(filePath))) {
+      const filePath = resolveSecurePath(configDir, filename);
+      if (!filePath || !(await fileExists(filePath))) {
         return res.status(404).json({ error: 'FILE_NOT_FOUND' });
       }
 
@@ -172,13 +173,15 @@ export function createConfigEditorRoutes(ctx: ConfigEditorRoutesContext): Router
 
           if (candidates.length > 0) {
             const nextDefault = candidates[0];
-            const oldPath = path.join(configDir, nextDefault.file);
-            const newPath = path.join(configDir, defaultConfigFilename);
-            await fs.rename(oldPath, newPath);
-            logger.info(
-              { from: nextDefault.file, to: defaultConfigFilename },
-              '[config-editor] Promoted new default config',
-            );
+            const oldPath = resolveSecurePath(configDir, nextDefault.file);
+            const newPath = resolveSecurePath(configDir, defaultConfigFilename);
+            if (oldPath && newPath) {
+              await fs.rename(oldPath, newPath);
+              logger.info(
+                { from: nextDefault.file, to: defaultConfigFilename },
+                '[config-editor] Promoted new default config',
+              );
+            }
           }
         } catch (promoteErr) {
           logger.error({ err: promoteErr }, '[config-editor] Failed to promote default config');
@@ -192,9 +195,11 @@ export function createConfigEditorRoutes(ctx: ConfigEditorRoutesContext): Router
           (f) => /\.homenet_bridge\.ya?ml$/.test(f) || f === defaultConfigFilename,
         );
         if (remainingConfigs.length === 0) {
-          const initMarker = path.join(configDir, '.initialized');
-          await fs.unlink(initMarker).catch(() => {});
-          logger.info('[config-editor] Last bridge deleted, .initialized marker removed');
+          const initMarker = resolveSecurePath(configDir, '.initialized');
+          if (initMarker) {
+            await fs.unlink(initMarker).catch(() => {});
+            logger.info('[config-editor] Last bridge deleted, .initialized marker removed');
+          }
         }
       } catch (err) {
         logger.warn({ err }, '[config-editor] Failed to check/remove .initialized marker');

--- a/packages/service/src/routes/config.routes.ts
+++ b/packages/service/src/routes/config.routes.ts
@@ -15,6 +15,7 @@ import { BASE_MQTT_PREFIX, ENTITY_TYPE_KEYS } from '../utils/constants.js';
 import type { RateLimiter } from '../utils/rate-limiter.js';
 import type { BridgeInstance, PersistableHomenetBridgeConfig } from '../types/index.js';
 import { saveBackup } from '../services/backup.service.js';
+import { resolveSecurePath } from '../utils/helpers.js';
 
 import {
   findConfigIndexByPortId,
@@ -198,7 +199,10 @@ export function createConfigRoutes(ctx: ConfigRoutesContext): Router {
       }
 
       // 2. Read full config
-      const configPath = path.join(ctx.configDir, targetConfigFile);
+      const configPath = resolveSecurePath(ctx.configDir, targetConfigFile);
+      if (!configPath) {
+        return res.status(404).json({ error: 'Config file not found' });
+      }
       const fileContent = await fs.readFile(configPath, 'utf8');
       const loadedYamlFromFile = yaml.load(fileContent) as {
         homenet_bridge: PersistableHomenetBridgeConfig;
@@ -345,7 +349,10 @@ export function createConfigRoutes(ctx: ConfigRoutesContext): Router {
       }
 
       // 2. Read full config
-      const configPath = path.join(ctx.configDir, targetConfigFile);
+      const configPath = resolveSecurePath(ctx.configDir, targetConfigFile);
+      if (!configPath) {
+        return res.status(404).json({ error: 'Config file not found' });
+      }
       const fileContent = await fs.readFile(configPath, 'utf8');
       const loadedYamlFromFile = yaml.load(fileContent) as {
         homenet_bridge: PersistableHomenetBridgeConfig;

--- a/packages/service/src/routes/gallery.routes.ts
+++ b/packages/service/src/routes/gallery.routes.ts
@@ -26,7 +26,7 @@ import {
   IS_DEV,
   LOCAL_GALLERY_DIR,
 } from '../utils/constants.js';
-import { getGalleryRawBaseUrl, getGalleryListUrl } from '../utils/helpers.js';
+import { getGalleryRawBaseUrl, getGalleryListUrl, resolveSecurePath } from '../utils/helpers.js';
 import { getFrontendSettings } from '../services/frontend-settings.service.js';
 import { saveBackup } from '../services/backup.service.js';
 import {
@@ -146,7 +146,10 @@ export function createGalleryRoutes(ctx: GalleryRoutesContext): Router {
       }
 
       if (IS_DEV) {
-        const localFilePath = path.join(LOCAL_GALLERY_DIR, normalizedPath);
+        const localFilePath = resolveSecurePath(LOCAL_GALLERY_DIR, normalizedPath);
+        if (!localFilePath) {
+          return res.status(400).json({ error: 'Invalid gallery path' });
+        }
         try {
           const fileContent = await fs.readFile(localFilePath, 'utf8');
           return res.type('text/yaml').send(fileContent);
@@ -754,7 +757,10 @@ export function createGalleryRoutes(ctx: GalleryRoutesContext): Router {
       }
 
       // Read the current config file
-      const configPath = path.join(CONFIG_DIR, targetConfigFile);
+      const configPath = resolveSecurePath(CONFIG_DIR, targetConfigFile);
+      if (!configPath) {
+        return res.status(400).json({ error: 'Invalid config file' });
+      }
       const fileContent = await fs.readFile(configPath, 'utf8');
       const loadedYamlFromFile = yaml.load(fileContent) as {
         homenet_bridge: PersistableHomenetBridgeConfig;

--- a/packages/service/src/routes/schema.routes.ts
+++ b/packages/service/src/routes/schema.routes.ts
@@ -6,6 +6,7 @@ import { Router } from 'express';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { resolveSecurePath } from '../utils/helpers.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -28,7 +29,10 @@ export function createSchemaRoutes(): Router {
       return res.status(400).json({ error: 'Invalid schema name' });
     }
 
-    const schemaPath = path.join(SCHEMA_DIR, `${schemaName}.schema.json`);
+    const schemaPath = resolveSecurePath(SCHEMA_DIR, `${schemaName}.schema.json`);
+    if (!schemaPath) {
+      return res.status(400).json({ error: 'Invalid schema name' });
+    }
 
     try {
       const content = await fs.readFile(schemaPath, 'utf-8');

--- a/packages/service/src/routes/setup.routes.ts
+++ b/packages/service/src/routes/setup.routes.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import fs from 'node:fs/promises';
 import yaml from 'js-yaml';
 import { type HomenetBridgeConfig, normalizeConfig, normalizePortId } from '@rs485-homenet/core';
+import { resolveSecurePath } from '../utils/helpers.js';
 import {
   type SetupWizardService,
   EMPTY_CONFIG_SENTINEL,
@@ -72,11 +73,10 @@ export function createSetupRoutes(ctx: SetupRoutesContext): Router {
       }
 
       const examples = await listExampleConfigs();
-      if (!examples.includes(filename)) {
+      const sourcePath = resolveSecurePath(examplesDir, filename);
+      if (!sourcePath || !examples.includes(filename)) {
         return res.status(404).json({ error: 'EXAMPLE_NOT_FOUND' });
       }
-
-      const sourcePath = path.join(examplesDir, filename);
 
       try {
         const rawContent = await fs.readFile(sourcePath, 'utf-8');
@@ -132,11 +132,11 @@ export function createSetupRoutes(ctx: SetupRoutesContext): Router {
       }
 
       const examples = await listExampleConfigs();
-      if (!examples.includes(filename)) {
+      const sourcePath = resolveSecurePath(examplesDir, filename);
+      if (!sourcePath || !examples.includes(filename)) {
         return res.status(404).json({ error: 'EXAMPLE_NOT_FOUND' });
       }
 
-      const sourcePath = path.join(examplesDir, filename);
       let parsedConfig: Record<string, any>;
 
       try {
@@ -230,11 +230,11 @@ export function createSetupRoutes(ctx: SetupRoutesContext): Router {
       }
 
       const examples = await listExampleConfigs();
-      if (!examples.includes(filename)) {
+      const sourcePath = resolveSecurePath(examplesDir, filename);
+      if (!sourcePath || !examples.includes(filename)) {
         return res.status(404).json({ error: 'EXAMPLE_NOT_FOUND' });
       }
 
-      const sourcePath = path.join(examplesDir, filename);
       let parsedConfig: unknown;
 
       try {
@@ -341,7 +341,10 @@ export function createSetupRoutes(ctx: SetupRoutesContext): Router {
         targetFilename = await getNextConfigFilename();
       }
 
-      const targetPath = path.join(configDir, targetFilename);
+      const targetPath = resolveSecurePath(configDir, targetFilename);
+      if (!targetPath) {
+        return res.status(400).json({ error: 'INVALID_TARGET_FILENAME' });
+      }
 
       let updatedYaml = '';
       let serialPathValue = '';
@@ -366,11 +369,10 @@ export function createSetupRoutes(ctx: SetupRoutesContext): Router {
         }
 
         const examples = await listExampleConfigs();
-        if (!examples.includes(filename)) {
+        const sourcePath = resolveSecurePath(examplesDir, filename);
+        if (!sourcePath || !examples.includes(filename)) {
           return res.status(404).json({ error: 'EXAMPLE_NOT_FOUND' });
         }
-
-        const sourcePath = path.join(examplesDir, filename);
         serialPathValue = serialPath.trim();
         const portIdValue = typeof portId === 'string' ? portId.trim() : undefined;
 

--- a/packages/service/src/utils/helpers.ts
+++ b/packages/service/src/utils/helpers.ts
@@ -65,7 +65,9 @@ export const fileExists = async (targetPath: string): Promise<boolean> => {
  */
 export const resolveSecurePath = (baseDir: string, filename: string): string | null => {
   const resolvedBase = path.resolve(baseDir);
-  const resolvedPath = path.resolve(baseDir, filename);
+  // Normalize filename to use platform-specific separators and handle potential bypasses
+  const normalizedFilename = filename.replace(/\\/g, path.sep);
+  const resolvedPath = path.resolve(baseDir, normalizedFilename);
 
   if (!resolvedPath.startsWith(resolvedBase + path.sep)) {
     return null;

--- a/packages/service/test/security_audit.test.ts
+++ b/packages/service/test/security_audit.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { resolveSecurePath } from '../src/utils/helpers.js';
+
+describe('Security Audit - Path Traversal', () => {
+  const baseDir = path.resolve('/app/config');
+
+  it('should block filenames that attempt to escape baseDir even if they match expected extension', () => {
+    const maliciousFiles = [
+      '../../../etc/passwd.homenet_bridge.yaml',
+      '..\\..\\..\\etc\\passwd.homenet_bridge.yaml',
+      './../../../etc/passwd.homenet_bridge.yaml',
+      '/etc/passwd.homenet_bridge.yaml',
+    ];
+
+    for (const file of maliciousFiles) {
+      const result = resolveSecurePath(baseDir, file);
+      expect(result, `Failed to block ${file}`).toBeNull();
+    }
+  });
+
+  it('should allow valid filenames', () => {
+    const validFiles = [
+      'default.homenet_bridge.yaml',
+      'living_room.homenet_bridge.yml',
+      'subdir/my.homenet_bridge.yaml'
+    ];
+
+    for (const file of validFiles) {
+      const result = resolveSecurePath(baseDir, file);
+      expect(result).not.toBeNull();
+      expect(result).toBe(path.resolve(baseDir, file));
+    }
+  });
+
+  it('should specifically test the weak regex scenario from the issue description', () => {
+    // Rationale: A payload like ../../../etc/passwd.homenet_bridge.yaml might be possible if the regex doesn't anchor the start.
+    const filename = '../../../etc/passwd.homenet_bridge.yaml';
+
+    // Simulating what happened in config-editor.routes.ts before the fix
+    const isValidConfigFilenameWeak = (f: string) => /\.homenet_bridge\.ya?ml$/.test(f);
+
+    // The weak regex indeed passes
+    expect(isValidConfigFilenameWeak(filename)).toBe(true);
+
+    // But resolveSecurePath should block it
+    expect(resolveSecurePath(baseDir, filename)).toBeNull();
+  });
+});


### PR DESCRIPTION
🎯 **What:** This PR fixes a Path Traversal vulnerability across several configuration and schema-related API endpoints.

⚠️ **Risk:** Without this fix, an attacker could potentially read, write, or delete arbitrary files on the server by providing malicious filenames (e.g., `../../../etc/passwd`) in the API parameters. The existing regex validation in some routes was insufficient as it didn"t anchor the start of the string.

🛡️ **Solution:** 
- Improved the `resolveSecurePath` utility in `packages/service/src/utils/helpers.ts` to normalize backslashes and strictly verify that resolved paths reside within the intended base directory using a prefix check.
- Consistently applied `resolveSecurePath` to all file system operations involving user-supplied filenames in:
    - `packages/service/src/routes/config-editor.routes.ts`
    - `packages/service/src/routes/config.routes.ts`
    - `packages/service/src/routes/setup.routes.ts`
    - `packages/service/src/routes/gallery.routes.ts`
    - `packages/service/src/routes/schema.routes.ts`
- Added a new security audit test suite to ensure various traversal vectors are blocked while valid paths remain accessible.

---
*PR created automatically by Jules for task [1753993319083297785](https://jules.google.com/task/1753993319083297785) started by @wooooooooooook*