### PR TITLE
fix(core): MQTT 재연결 시 bridge/status online retained 재발행

### DIFF
--- a/hassio-addon/CHANGELOG.md
+++ b/hassio-addon/CHANGELOG.md
@@ -1,6 +1,10 @@
 ** ⚠️ 업데이트 전 백업 권장 **
 - 오류가 있으면 homeasssutant [카페](https://cafe.naver.com/koreassistant), [깃헙](https://github.com/wooooooooooook/homenet2mqtt), [디스코드](https://discord.gg/kGwhUBMe5z) 등으로 알려주세요.
 
+v2.11.4
+- fix: mqtt 연결 끊김 후 재연결시 offline상태가 안풀리는 문제 수정
+
+
 v2.11.3
 - fix: 갤러리 댓글 기능이 homeassistant ingress환경에서는 작동하지 않는 문제 개선
   - ha ingress에서는 github login이 불가하여 giscus댓글작성이 안되어 우회하여 github discussion링크와 개발자계정으로 댓글 남기기 지원

--- a/packages/core/src/mqtt/discovery-manager.ts
+++ b/packages/core/src/mqtt/discovery-manager.ts
@@ -114,19 +114,23 @@ export class DiscoveryManager {
       },
     );
 
-    // Publish bridge online status
-    this.publisher.publish(this.bridgeStatusTopic, 'online', { retain: true });
-    logger.info('[DiscoveryManager] Published bridge online status');
+    this.publishBridgeOnlineStatus();
   }
 
   public discover(): void {
     logger.info('[DiscoveryManager] Checking discovery eligibility for configured entities');
+
+    this.publishBridgeOnlineStatus();
 
     for (const entity of this.entities) {
       this.publishDiscoveryIfEligible(entity);
     }
   }
 
+  private publishBridgeOnlineStatus(): void {
+    this.publisher.publish(this.bridgeStatusTopic, 'online', { retain: true });
+    logger.info('[DiscoveryManager] Published bridge online status');
+  }
   private collectEntities(): Array<EntityConfig & { type: string }> {
     return [
       ...(this.config.light || []).map((e) => ({ ...e, type: 'light' })),

--- a/packages/core/test/discovery_manager.test.ts
+++ b/packages/core/test/discovery_manager.test.ts
@@ -133,6 +133,23 @@ describe('DiscoveryManager', () => {
     discoveryManager.setup();
   });
 
+  it('MQTT 재연결 시 bridge online 상태를 retain으로 다시 발행한다', () => {
+    const statusTopic = 'homenet2mqtt/homedevice1/bridge/status';
+
+    const initialCalls = mockPublisher.publish.mock.calls.filter(
+      (args: any[]) => args[0] === statusTopic && args[1] === 'online' && args[2]?.retain === true,
+    );
+    expect(initialCalls.length).toBe(1);
+
+    discoveryManager.discover();
+    discoveryManager.discover();
+
+    const republishedCalls = mockPublisher.publish.mock.calls.filter(
+      (args: any[]) => args[0] === statusTopic && args[1] === 'online' && args[2]?.retain === true,
+    );
+    expect(republishedCalls.length).toBe(3);
+  });
+
   it('상태 패킷 수신 후에만 스위치 디스커버리를 발행한다', () => {
     discoveryManager.discover();
 


### PR DESCRIPTION
### Motivation
- MQTT 연결이 끊긴 뒤 LWT로 남은 `bridge/status=offline`이 재연결 시 덮어쓰기되지 않아 Home Assistant에서 엔티티가 `unavailable`로 고정되는 문제를 해결하기 위해 변경했습니다.

### Description
- `DiscoveryManager`에 `publishBridgeOnlineStatus()` 메서드를 추가하고 `setup()`과 `discover()`에서 공통으로 호출하도록 변경했습니다.
- 기존에는 `setup()` 시 한 번만 `bridge/status=online (retain:true)`을 발행했으나, 이제 `discover()` 호출 시에도 재발행하여 재연결 상황을 덮어씁니다.
- 관련 단위 테스트를 추가하여 `discover()` 연속 호출 시 `bridge/status`의 `online (retain:true)` 발행이 증가하는지를 검증했습니다 (`packages/core/test/discovery_manager.test.ts`).

### Testing
- `pnpm format`를 실행하여 코드 포맷을 적용했고 성공했습니다.
- `pnpm build`를 실행하여 패키지 빌드가 성공했습니다.
- `pnpm lint`를 실행하여 린트가 통과했습니다.
- `pnpm test`를 실행하여 전체 테스트가 성공했고 새로 추가한 테스트 (`MQTT 재연결 시 bridge online 상태를 retain으로 다시 발행한다`)도 통과했습니다.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a008f5db5f8832cab0f31289c3e6609)