### PR TITLE
🧹 Remove unused imports and refactor type imports in service package

### DIFF
--- a/packages/service/src/activity-log.service.ts
+++ b/packages/service/src/activity-log.service.ts
@@ -1,10 +1,10 @@
-import {
-  eventBus,
-  type StateChangedEvent,
-  type MqttMessageEvent,
-  type AutomationGuardEvent,
-  type AutomationActionEvent,
-  type ScriptActionEvent,
+import { eventBus } from '@rs485-homenet/core';
+import type {
+  StateChangedEvent,
+  MqttMessageEvent,
+  AutomationGuardEvent,
+  AutomationActionEvent,
+  ScriptActionEvent,
 } from '@rs485-homenet/core';
 
 export interface ActivityLog {

--- a/packages/service/src/routes/controls.routes.ts
+++ b/packages/service/src/routes/controls.routes.ts
@@ -9,7 +9,6 @@ import { logger, normalizePortId, normalizeConfig } from '@rs485-homenet/core';
 import { dumpConfigToYaml } from '../utils/yaml-dumper.js';
 import type { HomenetBridgeConfig } from '@rs485-homenet/core';
 import type { AutomationConfig, ScriptConfig } from '@rs485-homenet/core/config/types';
-import { ENTITY_TYPE_KEYS } from '../utils/constants.js';
 import type { RateLimiter } from '../utils/rate-limiter.js';
 import type {
   BridgeInstance,

--- a/packages/service/src/routes/entities.routes.ts
+++ b/packages/service/src/routes/entities.routes.ts
@@ -5,7 +5,7 @@
 import { Router } from 'express';
 import path from 'node:path';
 import fs from 'node:fs/promises';
-import { logger, normalizeConfig, normalizePortId } from '@rs485-homenet/core';
+import { logger, normalizeConfig } from '@rs485-homenet/core';
 import type { HomenetBridgeConfig } from '@rs485-homenet/core';
 import { dumpConfigToYaml } from '../utils/yaml-dumper.js';
 import { ENTITY_TYPE_KEYS } from '../utils/constants.js';


### PR DESCRIPTION
🎯 **What:** Removed unused imports in `entities.routes.ts` and `controls.routes.ts`. Refactored mixed imports in `activity-log.service.ts` to use explicit `import type` for clarity and better code health.

💡 **Why:** Improving maintainability and readability by cleaning up dead code and making type usage explicit.

✅ **Verification:** Performed manual code review and verified usage of all remaining imports. Checked syntax by reading files. Workspace cleaned of all analysis scripts.

✨ **Result:** Cleaner codebase with reduced noise and explicit type boundaries.

---
*PR created automatically by Jules for task [8210682642966242052](https://jules.google.com/task/8210682642966242052) started by @wooooooooooook*