### PR TITLE
🧪 [testing improvement] Add tests for getStateCache and clearStateCache

### DIFF
--- a/packages/core/test/state/store.test.ts
+++ b/packages/core/test/state/store.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getStateCache, clearStateCache, stateCache } from '../../src/state/store.js';
+
+describe('store', () => {
+  beforeEach(() => {
+    clearStateCache();
+  });
+
+  describe('getStateCache', () => {
+    it('should return the stateCache Map', () => {
+      const cache = getStateCache();
+      expect(cache).toBeInstanceOf(Map);
+      expect(cache).toBe(stateCache);
+    });
+  });
+
+  describe('clearStateCache', () => {
+    it('should clear all entries from the stateCache', () => {
+      stateCache.set('key1', 'value1');
+      stateCache.set('key2', { foo: 'bar' });
+
+      expect(stateCache.size).toBe(2);
+
+      clearStateCache();
+
+      expect(stateCache.size).toBe(0);
+      expect(getStateCache().size).toBe(0);
+    });
+
+    it('should work correctly when the cache is already empty', () => {
+      expect(stateCache.size).toBe(0);
+
+      clearStateCache();
+
+      expect(stateCache.size).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR adds unit tests for `getStateCache` and `clearStateCache` in the core package's state store.

📊 **Coverage:** What scenarios are now tested
- `getStateCache()` returns the correct Map instance (`stateCache`).
- `clearStateCache()` removes all entries from the cache Map.
- `clearStateCache()` handles empty cache correctly.

✨ **Result:** The improvement in test coverage
The state store logic is now formally verified, ensuring that cache management works as expected, which is critical for state re-publishing during system restarts.

---
*PR created automatically by Jules for task [12623185448785796075](https://jules.google.com/task/12623185448785796075) started by @wooooooooooook*