### PR TITLE
🧹 Improve HexSeqWrapper types in yaml-dumper

### DIFF
--- a/packages/service/src/utils/yaml-dumper.ts
+++ b/packages/service/src/utils/yaml-dumper.ts
@@ -2,7 +2,10 @@ import yaml from 'js-yaml';
 import { ENTITY_TYPE_KEYS } from './constants.js';
 
 class HexSeqWrapper {
-  constructor(public items: any[]) {}
+  items: unknown[];
+  constructor(items: unknown[]) {
+    this.items = items;
+  }
 }
 
 const HexSeqType = new yaml.Type('!hexSeq', {
@@ -10,7 +13,7 @@ const HexSeqType = new yaml.Type('!hexSeq', {
   instanceOf: HexSeqWrapper,
   represent: (obj: any) => {
     // Format each item as 0xXX and join with comma
-    const hexItems = obj.items.map((v: any) => {
+    const hexItems = obj.items.map((v: unknown) => {
       if (typeof v === 'number') {
         const h = v.toString(16).toUpperCase();
         return '0x' + (h.length < 2 ? '0' + h : h);


### PR DESCRIPTION
* 🎯 **What:** The `HexSeqWrapper` class constructor parameter property `items: any[]` and the `represent` method's `map((v: any) => ...)` callback were updated to use `unknown` instead of `any`.
* 💡 **Why:** This avoids using the loose `any` type in an array mapping callback and class property, leading to stricter type safety and improving code maintainability. It addresses the reported code health issue "Avoid using any in map callback for array elements".
* ✅ **Verification:** Made sure the change preserves identical behavior. The `v` in the `.map` callback is already checked at runtime via `typeof v === 'number'`, which works perfectly with `unknown` and correctly narrows the type inside the branch. Verified changes via local checks and test suite commands in the restricted environment.
* ✨ **Result:** The code no longer relies on `any` for array elements in the `yaml-dumper`, establishing a more strongly-typed interface.

---
*PR created automatically by Jules for task [2462296157215217867](https://jules.google.com/task/2462296157215217867) started by @wooooooooooook*