### PR TITLE
🧹 [Code Health] Replace 'any' with explicit type in dumpConfigToYaml

### DIFF
--- a/packages/service/src/services/config-editor.service.ts
+++ b/packages/service/src/services/config-editor.service.ts
@@ -1,3 +1,4 @@
+import type { HomenetBridgeConfig } from '@rs485-homenet/core';
 import yaml from 'js-yaml';
 
 export type ConfigEditorDeps = {
@@ -5,7 +6,7 @@ export type ConfigEditorDeps = {
   defaultConfigFilename: string;
   configRestartFlag: string;
   fileExists: (targetPath: string) => Promise<boolean>;
-  dumpConfigToYaml: (config: any, options?: yaml.DumpOptions) => string;
+  dumpConfigToYaml: (config: Partial<HomenetBridgeConfig> | Record<string, any>, options?: yaml.DumpOptions) => string;
   saveBackup: (configPath: string, config: any, reason: string) => Promise<string>;
   triggerRestart: () => Promise<void>;
   configRateLimiter: { check: (key: string) => boolean };

--- a/packages/service/src/services/setup.service.ts
+++ b/packages/service/src/services/setup.service.ts
@@ -21,7 +21,7 @@ export type SetupWizardDeps = {
   configRestartFlag: string;
   envConfigFilesSource: string | null;
   fileExists: (targetPath: string) => Promise<boolean>;
-  dumpConfigToYaml: (config: any, options?: yaml.DumpOptions) => string;
+  dumpConfigToYaml: (config: Partial<HomenetBridgeConfig> | Record<string, any>, options?: yaml.DumpOptions) => string;
   saveBackup: (configPath: string, config: any, reason: string) => Promise<string>;
   triggerRestart: () => Promise<void>;
   serialTestRateLimiter: { check: (key: string) => boolean };

--- a/packages/service/src/utils/yaml-dumper.ts
+++ b/packages/service/src/utils/yaml-dumper.ts
@@ -1,8 +1,12 @@
 import yaml from 'js-yaml';
+import type { HomenetBridgeConfig } from '@rs485-homenet/core';
 import { ENTITY_TYPE_KEYS } from './constants.js';
 
 class HexSeqWrapper {
-  constructor(public items: any[]) {}
+  items: any[];
+  constructor(items: any[]) {
+    this.items = items;
+  }
 }
 
 const HexSeqType = new yaml.Type('!hexSeq', {
@@ -76,7 +80,7 @@ function markHex(obj: any): any {
   return obj;
 }
 
-export function dumpConfigToYaml(config: any, options: yaml.DumpOptions = {}): string {
+export function dumpConfigToYaml(config: Partial<HomenetBridgeConfig> | Record<string, any>, options: yaml.DumpOptions = {}): string {
   const markedConfig = markHex(config);
   const dump = yaml.dump(markedConfig, {
     schema: SCHEMA,


### PR DESCRIPTION
🎯 **What:** The `config` parameter in `dumpConfigToYaml` (across `packages/service/src/utils/yaml-dumper.ts`, `setup.service.ts`, and `config-editor.service.ts`) was typed as `any`. It has now been replaced with `Partial<HomenetBridgeConfig> | Record<string, any>` to accurately reflect that it accepts both full/partial configurations and individual entities. Additionally, the `HexSeqWrapper` class inside `yaml-dumper.ts` was refactored to use standard class properties instead of TypeScript constructor parameter properties to improve compatibility.

💡 **Why:** Relying on `any` bypasses type checking and makes it harder to understand what data structures a function expects. Providing a specific, descriptive union type communicates the API intent more clearly while maintaining the flexibility required by existing calls (which dump entire configs or single entity fragments).

✅ **Verification:** Verified by inspecting the updated method signatures, confirming parsing correctness through Node's `--experimental-strip-types` tool, and ensuring that `bun test` passes relevant tests without functional regressions. Format issues were prevented by making targeted structural edits. 

✨ **Result:** Enhanced type clarity and robustness in the `yaml-dumper` utility and associated service dependencies, resulting in a cleaner and more predictable API surface.

---
*PR created automatically by Jules for task [657051298981997974](https://jules.google.com/task/657051298981997974) started by @wooooooooooook*