### PR TITLE
Revoke discovery and clear retained MQTT messages for deleted entities

### DIFF
--- a/hassio-addon/CHANGELOG.md
+++ b/hassio-addon/CHANGELOG.md
@@ -1,6 +1,10 @@
 ** ⚠️ 업데이트 전 백업 권장 **
 - 오류가 있으면 homeasssutant [카페](https://cafe.naver.com/koreassistant), [깃헙](https://github.com/wooooooooooook/homenet2mqtt), [디스코드](https://discord.gg/kGwhUBMe5z) 등으로 알려주세요.
 
+v2.11.5
+-fix: 엔티티 삭제시 mqtt retain message도 삭제하도록 수정
+
+
 v2.11.4
 - fix: mqtt 연결 끊김 후 재연결시 offline상태가 안풀리는 문제 수정
 

--- a/hassio-addon/CHANGELOG.md
+++ b/hassio-addon/CHANGELOG.md
@@ -2,7 +2,7 @@
 - 오류가 있으면 homeasssutant [카페](https://cafe.naver.com/koreassistant), [깃헙](https://github.com/wooooooooooook/homenet2mqtt), [디스코드](https://discord.gg/kGwhUBMe5z) 등으로 알려주세요.
 
 v2.11.5
--fix: 엔티티 삭제시 mqtt retain message도 삭제하도록 수정
+- fix: 엔티티 삭제시 mqtt retain message도 삭제하도록 수정
 
 
 v2.11.4

--- a/packages/core/src/service/bridge.service.ts
+++ b/packages/core/src/service/bridge.service.ts
@@ -180,6 +180,23 @@ export class HomeNetBridge extends EventEmitter {
     return this._mqttClient.clearRetainedMessages(this.commonMqttTopicPrefix);
   }
 
+  async clearRetainedMessagesForEntity(entityId: string): Promise<number> {
+    if (!this._mqttClient || !this._mqttClient.isConnected) {
+      throw new Error('MQTT client is not connected');
+    }
+
+    const contexts = [...this.portContexts.values()];
+    if (contexts.length === 0) return 0;
+
+    let totalCleared = 0;
+    for (const context of contexts) {
+      totalCleared += await this._mqttClient.clearRetainedMessages(
+        `${this.getMqttTopicPrefix(context.portId)}/${entityId}`,
+      );
+    }
+    return totalCleared;
+  }
+
   /**
    * Construct a packet with optional header, footer, and checksum based on configuration
    */

--- a/packages/service/src/routes/entities.routes.ts
+++ b/packages/service/src/routes/entities.routes.ts
@@ -151,6 +151,12 @@ export function createEntitiesRoutes(ctx: EntitiesRoutesContext): Router {
       const normalizedConfig = normalizeConfig(
         loadedYamlFromFile.homenet_bridge as HomenetBridgeConfig,
       );
+      const bridgeInstance = findBridgeForEntity(
+        ctx.getCurrentConfigs(),
+        ctx.getBridges(),
+        ctx.getCurrentConfigFiles(),
+        entityId,
+      );
 
       let targetEntity: any | null = null;
       for (const type of ENTITY_TYPE_KEYS) {
@@ -363,6 +369,12 @@ export function createEntitiesRoutes(ctx: EntitiesRoutesContext): Router {
       const normalizedConfig = normalizeConfig(
         loadedYamlFromFile.homenet_bridge as HomenetBridgeConfig,
       );
+      const bridgeInstance = findBridgeForEntity(
+        ctx.getCurrentConfigs(),
+        ctx.getBridges(),
+        ctx.getCurrentConfigFiles(),
+        entityId,
+      );
 
       // Backup
       const backupPath = await saveBackup(configPath, loadedYamlFromFile, 'entity_delete');
@@ -396,6 +408,22 @@ export function createEntitiesRoutes(ctx: EntitiesRoutesContext): Router {
       ctx.setCurrentRawConfigs(configIndex, normalizedConfig);
       ctx.setCurrentConfigs(configIndex, normalizedConfig);
       ctx.rebuildPortMappings();
+
+      if (bridgeInstance) {
+        const revokeResult = bridgeInstance.bridge.revokeDiscovery(entityId);
+        if (!revokeResult.success) {
+          logger.warn(
+            { entityId, error: revokeResult.error },
+            '[service] Failed to revoke discovery during entity delete',
+          );
+        }
+
+        const clearedCount = await bridgeInstance.bridge.clearRetainedMessagesForEntity(entityId);
+        logger.info(
+          { entityId, clearedCount },
+          '[service] Cleared retained MQTT messages during entity delete',
+        );
+      }
 
       logger.info(
         `[service] Entity ${entityId} deleted. Backup created at ${path.basename(backupPath)}`,

--- a/packages/service/test/utils/bridge-errors.test.ts
+++ b/packages/service/test/utils/bridge-errors.test.ts
@@ -87,12 +87,22 @@ describe('bridge-errors utils', () => {
 
   describe('mapSerialError', () => {
     it('should map various serial errors', () => {
-      expect(mapSerialError({ code: 'ENOENT', message: 'no such file' }, 'port1').code).toBe('SERIAL_PATH_NOT_FOUND');
-      expect(mapSerialError({ code: 'EACCES', message: 'permission denied' }).code).toBe('SERIAL_PERMISSION_DENIED');
+      expect(mapSerialError({ code: 'ENOENT', message: 'no such file' }, 'port1').code).toBe(
+        'SERIAL_PATH_NOT_FOUND',
+      );
+      expect(mapSerialError({ code: 'EACCES', message: 'permission denied' }).code).toBe(
+        'SERIAL_PERMISSION_DENIED',
+      );
       expect(mapSerialError({ code: 'EBUSY', message: 'busy' }).code).toBe('SERIAL_PORT_BUSY');
-      expect(mapSerialError({ code: 'ENOTFOUND', message: 'not found' }).code).toBe('SERIAL_HOST_NOT_FOUND');
-      expect(mapSerialError({ code: 'ECONNREFUSED', message: 'refused' }).code).toBe('SERIAL_CONNECTION_REFUSED');
-      expect(mapSerialError({ code: 'ETIMEDOUT', message: 'timeout' }).code).toBe('SERIAL_CONNECTION_TIMEOUT');
+      expect(mapSerialError({ code: 'ENOTFOUND', message: 'not found' }).code).toBe(
+        'SERIAL_HOST_NOT_FOUND',
+      );
+      expect(mapSerialError({ code: 'ECONNREFUSED', message: 'refused' }).code).toBe(
+        'SERIAL_CONNECTION_REFUSED',
+      );
+      expect(mapSerialError({ code: 'ETIMEDOUT', message: 'timeout' }).code).toBe(
+        'SERIAL_CONNECTION_TIMEOUT',
+      );
       expect(mapSerialError('유효한 path가 필요합니다').code).toBe('SERIAL_PATH_MISSING');
       expect(mapSerialError(new Error('Unknown error')).code).toBe('SERIAL_CONNECT_FAILED');
     });


### PR DESCRIPTION
### Motivation
- Ensure that when an entity is removed from a config the bridge stops advertising it and any retained MQTT messages for that entity are removed to avoid stale state in MQTT brokers and clients.

### Description
- Add `clearRetainedMessagesForEntity(entityId)` to `HomeNetBridge` to clear retained MQTT messages for a specific entity across all port contexts by calling the MQTT client's `clearRetainedMessages` with per-port topic prefixes.
- Use `findBridgeForEntity(...)` in the entities routes and invoke the bridge to `revokeDiscovery(entityId)` and `clearRetainedMessagesForEntity(entityId)` during entity deletion, with logging for failures and the cleared count.
- Include small formatting adjustments in tests (`bridge-errors.test.ts`) with no behavioral changes.

### Testing
- Ran the package test suite (`yarn test`) for the service package and the relevant unit tests; all tests passed.
- Performed a TypeScript build (`yarn build`) to validate compilation; build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0687b52a14832c8ceecad9d1063681)