### PR TITLE
🧹 refactor(service): improve hex string formatting with padStart

### DIFF
--- a/packages/service/src/utils/yaml-dumper.ts
+++ b/packages/service/src/utils/yaml-dumper.ts
@@ -16,8 +16,7 @@ const HexSeqType = new yaml.Type('!hexSeq', {
     // Format each item as 0xXX and join with comma
     const hexItems = obj.items.map((v: unknown) => {
       if (typeof v === 'number') {
-        const h = v.toString(16).toUpperCase();
-        return '0x' + (h.length < 2 ? '0' + h : h);
+        return `0x${v.toString(16).padStart(2, '0').toUpperCase()}`;
       }
       return v;
     });


### PR DESCRIPTION
🎯 **What:** Refactored hex string formatting in `yaml-dumper.ts` to use `padStart(2, '0')`.
💡 **Why:** This improves the readability and maintainability of the code by replacing manual string length checking with a standard JavaScript string method.
✅ **Verification:** Verified by running `pnpm format`, `pnpm lint`, and the full test suite (`pnpm test`), ensuring no regressions were introduced.
✨ **Result:** Cleaner and more modern code for generating hex strings in the YAML dumper.

---
*PR created automatically by Jules for task [521786897588243277](https://jules.google.com/task/521786897588243277) started by @wooooooooooook*