### PR TITLE
🧹 [code health] Remove deprecated parseIncomingPacket method

### DIFF
--- a/packages/core/src/protocol/packet-processor.ts
+++ b/packages/core/src/protocol/packet-processor.ts
@@ -250,19 +250,4 @@ export class PacketProcessor extends EventEmitter {
 
     return cmd;
   }
-
-  /**
-   * @deprecated This method is legacy and incompatible with the stream-based parsing architecture.
-   * Use `processChunk` instead, which handles buffering and parsing via `ProtocolManager`.
-   */
-  public parseIncomingPacket(
-    _packet: number[],
-    _allEntities: EntityConfig[],
-  ): { parsedStates: { entityId: string; state: any }[]; checksumValid: boolean } {
-    // This method is no longer compatible with the stream-based approach.
-    // We should update the caller (StateManager) to use processChunk.
-    // For now, return empty to avoid breaking if called, but log warning.
-    logger.warn('PacketProcessor.parseIncomingPacket is deprecated. Use processChunk instead.');
-    return { parsedStates: [], checksumValid: true };
-  }
 }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the deprecated and unused `parseIncomingPacket` method from `PacketProcessor` in `packages/core/src/protocol/packet-processor.ts`.

💡 **Why:** How this improves maintainability
The method was explicitly marked as legacy, incompatible with the new architecture (`processChunk`), and simply logged a warning before returning an empty response. Removing it removes dead code, preventing future developers from accidentally using it and reducing technical debt.

✅ **Verification:** How you confirmed the change is safe
- Confirmed with `grep` that `parseIncomingPacket` is not used anywhere in the codebase.
- Ran `pnpm install`.
- Ran `pnpm format`, `pnpm lint`, and `pnpm test` (all 799 tests passed).
- Built the `core` package with `pnpm --filter core build` to guarantee no TypeScript compile errors occurred due to removing the method.

✨ **Result:** The improvement achieved
A cleaner `PacketProcessor` interface with less legacy debt and dead code.

---
*PR created automatically by Jules for task [3054172639302120752](https://jules.google.com/task/3054172639302120752) started by @wooooooooooook*