### PR TITLE
로컬 복원 상태 토픽 형식 수정 및 non-restorable optimistic 엔티티의 디스크 캐시 복원 방지

### DIFF
--- a/hassio-addon/CHANGELOG.md
+++ b/hassio-addon/CHANGELOG.md
@@ -1,6 +1,12 @@
 ** ⚠️ 업데이트 전 백업 권장 **
 - 오류가 있으면 homeassistant [카페](https://cafe.naver.com/koreassistant), [깃헙](https://github.com/wooooooooooook/homenet2mqtt), [디스코드](https://discord.gg/kGwhUBMe5z) 등으로 알려주세요.
 
+v3.1.1
+⚠️ 업데이트 후 `h2m설정 - 애플리케이션관리 - MQTT 메시지 초기화`를 실행하시기바랍니다.
+- fix: portId가 중복되거나 엔티티 ID의 .가 /로 바뀌는 문제를 수정
+- fix: optimistic: true이지만 restore_mode가 복원 모드가 아닌(ALWAYS_OFF/ALWAYS_ON) 엔티티가 낡은 캐시 값으로 덮어써지는 문제 수정
+
+
 v3.1.0
 - add: samsung hvac 지원 추가 (NASA, non-NASA프로토콜) [esphome용 컴포넌트](https://docs.samsung-hvac.aran.net.tr/wiki/), [https://github.com/eigger/esphome_samsung_hvac_bus](https://github.com/eigger/esphome_samsung_hvac_bus)에서 프로토콜 정보를 가져와서 추가했습니다.
 

--- a/packages/core/src/state/state-manager.ts
+++ b/packages/core/src/state/state-manager.ts
@@ -52,6 +52,7 @@ export class StateManager {
   private sharedStates?: Map<string, Record<string, any>>;
   private internalEntityIds: Set<string>;
   private configEntityIds: Set<string>;
+  private nonRestorableOptimisticEntityIds: Set<string>;
   private statePublisher?: StatePublisher;
   private statesCachePath: string | null = null;
   private saveTimer: NodeJS.Timeout | null = null;
@@ -89,12 +90,17 @@ export class StateManager {
 
     // Build known entity ID set from config (must happen before loadLocalCache)
     this.configEntityIds = new Set<string>();
+    this.nonRestorableOptimisticEntityIds = new Set<string>();
     for (const type of ENTITY_TYPE_KEYS) {
       const entities = config[type] as EntityConfig[] | undefined;
       if (entities) {
         for (const entity of entities) {
           if (entity.id) {
             this.configEntityIds.add(entity.id);
+            const mode: RestoreMode = entity.restore_mode ?? 'ALWAYS_OFF';
+            if (entity.optimistic && !isRestorableMode(mode)) {
+              this.nonRestorableOptimisticEntityIds.add(entity.id);
+            }
           }
         }
       }
@@ -464,7 +470,10 @@ export class StateManager {
         let restoredCount = 0;
         let skippedCount = 0;
         for (const [entityId, state] of Object.entries(cached)) {
-          if (!this.configEntityIds.has(entityId)) {
+          if (
+            !this.configEntityIds.has(entityId) ||
+            this.nonRestorableOptimisticEntityIds.has(entityId)
+          ) {
             skippedCount++;
             continue;
           }
@@ -481,9 +490,9 @@ export class StateManager {
         if (skippedCount > 0) {
           logger.info(
             { skipped: skippedCount },
-            '[StateManager] Skipped orphan entities not in current config',
+            '[StateManager] Skipped unavailable or non-restorable entities from states cache',
           );
-          // Rewrite cache file with only valid entities to permanently remove orphans
+          // Rewrite cache file with only restorable valid entities to permanently remove stale entries
           const cleanedData = Object.fromEntries(this.deviceStates);
           await fsPromises.writeFile(
             this.statesCachePath,
@@ -492,7 +501,7 @@ export class StateManager {
           );
           logger.info(
             { path: this.statesCachePath },
-            '[StateManager] Cleaned orphan entities from states cache file',
+            '[StateManager] Cleaned skipped entities from states cache file',
           );
         }
       }
@@ -537,7 +546,7 @@ export class StateManager {
     for (const [entityId, state] of this.deviceStates.entries()) {
       if (this.internalEntityIds.has(entityId)) continue;
 
-      const topic = `${this.topicPrefix}/${this.portId}/${entityId.replace('.', '/')}/state`;
+      const topic = `${this.topicPrefix}/${entityId}/state`;
       const payload = typeof state === 'string' ? state : JSON.stringify(state);
       const timestamp = new Date().toISOString();
 

--- a/packages/core/test/state/state-persistence.test.ts
+++ b/packages/core/test/state/state-persistence.test.ts
@@ -5,13 +5,14 @@ import os from 'node:os';
 import { StateManager } from '../../src/state/state-manager.js';
 import { PacketProcessor } from '../../src/protocol/packet-processor.js';
 import { HomenetBridgeConfig } from '../../src/config/types.js';
+import { eventBus } from '../../src/service/event-bus.js';
+
+const PORT_ID = 'test-port';
+const cacheFileName = `states_cache_${PORT_ID}.json`;
 
 describe('Local State Persistence Cache', () => {
   let tempDir: string;
   let configPath: string;
-
-  const PORT_ID = 'test-port';
-  const cacheFileName = `states_cache_${PORT_ID}.json`;
 
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homenet-test-'));
@@ -282,5 +283,124 @@ describe('Local State Persistence Cache', () => {
 
     expect(sm2.getEntityState('switch_b')).toEqual({ state: 'OFF' });
     expect(sm2.getEntityState('light_a')).toBeUndefined();
+  });
+});
+
+describe('Local State Restore Publishing', () => {
+  let tempDir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homenet-test-'));
+    configPath = path.join(tempDir, 'homenet_bridge.yaml');
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  it('should publish restored local states on the same topic as regular state updates', () => {
+    const config: HomenetBridgeConfig = {
+      serial: {
+        portId: PORT_ID,
+        path: '/dev/null',
+        baud_rate: 9600,
+        data_bits: 8,
+        parity: 'none',
+        stop_bits: 1,
+      },
+      light: [{ id: 'livingroom_light_1', name: 'Living Room Light' }],
+    };
+    const packetProcessor = new PacketProcessor(config, { getEntityState: () => undefined } as any);
+    const published: Array<{ topic: string; payload: string }> = [];
+    const listener = (event: { topic: string; payload: string }) =>
+      published.push({ topic: event.topic, payload: event.payload });
+    eventBus.on('state:changed', listener);
+    const stateManager = new StateManager(PORT_ID, config, packetProcessor, 'homenet');
+
+    try {
+      stateManager.updateEntityState('livingroom_light_1', { state: 'OFF' });
+      published.length = 0;
+
+      stateManager.publishRestoredLocalStates();
+    } finally {
+      eventBus.off('state:changed', listener);
+    }
+
+    expect(published).toEqual([
+      {
+        topic: 'homenet/livingroom_light_1/state',
+        payload: JSON.stringify({ state: 'OFF' }),
+      },
+    ]);
+  });
+
+  it('should preserve dots in restored local state topics', () => {
+    const config: HomenetBridgeConfig = {
+      serial: {
+        portId: PORT_ID,
+        path: '/dev/null',
+        baud_rate: 9600,
+        data_bits: 8,
+        parity: 'none',
+        stop_bits: 1,
+      },
+      light: [{ id: 'light.livingroom', name: 'Living Room Light' }],
+    };
+    const packetProcessor = new PacketProcessor(config, { getEntityState: () => undefined } as any);
+    const published: Array<{ topic: string; payload: string }> = [];
+    const listener = (event: { topic: string; payload: string }) =>
+      published.push({ topic: event.topic, payload: event.payload });
+    eventBus.on('state:changed', listener);
+    const stateManager = new StateManager(PORT_ID, config, packetProcessor, 'homenet');
+
+    try {
+      stateManager.updateEntityState('light.livingroom', { state: 'ON' });
+      published.length = 0;
+
+      stateManager.publishRestoredLocalStates();
+    } finally {
+      eventBus.off('state:changed', listener);
+    }
+
+    expect(published[0]?.topic).toBe('homenet/light.livingroom/state');
+  });
+
+  it('should not restore non-restorable optimistic entities from disk cache', async () => {
+    const config: HomenetBridgeConfig = {
+      serial: {
+        portId: PORT_ID,
+        path: '/dev/null',
+        baud_rate: 9600,
+        data_bits: 8,
+        parity: 'none',
+        stop_bits: 1,
+      },
+      light: [{ id: 'light.livingroom', name: 'Living Room Light', optimistic: true }],
+    };
+    const packetProcessor = new PacketProcessor(config, { getEntityState: () => undefined } as any);
+    const cacheFilePath = path.join(tempDir, cacheFileName);
+    fs.writeFileSync(
+      cacheFilePath,
+      JSON.stringify({ 'light.livingroom': { state: 'ON' } }),
+      'utf8',
+    );
+
+    const stateManager = await StateManager.create(
+      PORT_ID,
+      config,
+      packetProcessor,
+      'homenet',
+      new Map(),
+      undefined,
+      configPath,
+    );
+
+    expect(stateManager.getEntityState('light.livingroom')).toEqual({ state: 'OFF' });
+    expect(JSON.parse(fs.readFileSync(cacheFilePath, 'utf8'))).toEqual({
+      'light.livingroom': { state: 'OFF' },
+    });
   });
 });


### PR DESCRIPTION
### Motivation
- `publishRestoredLocalStates()`가 기존 상태 업데이트와 다른 MQTT 토픽을 생성해 `portId`가 중복되거나 엔티티 ID의 `.`가 `/`로 바뀌는 문제를 유발했습니다. 이로 인해 UI/대시보드에 상태가 올바르게 보이지 않았습니다. 
- 디스크 캐시에서 복원할 때 `optimistic: true`이지만 `restore_mode`가 복원 모드가 아닌(`ALWAYS_OFF`/`ALWAYS_ON`) 엔티티가 낡은 캐시 값으로 덮어써지는 문제가 있었습니다.

### Description
- `StateManager`에 `nonRestorableOptimisticEntityIds` 집합을 추가해 `optimistic`이면서 복원 모드가 아닌 엔티티를 추적하도록 했습니다.
- 로컬 캐시 로드(`loadLocalCache`) 시 위 집합에 포함된 엔티티를 복원 대상에서 건너뛰도록 변경했습니다.
- `publishRestoredLocalStates()`에서 복원 시 사용하는 MQTT 토픽을 일반 상태 업데이트와 동일한 형식인 ``${topicPrefix}/${entityId}/state``로 변경해 `portId` 중복 및 `.` 치환 문제를 해결했습니다.
- 관련 로그 메시지와 주석을 명확하게 수정했고, 회귀 테스트를 `packages/core/test/state/state-persistence.test.ts`에 추가하여 복원 시 발행 토픽 형식과 non-restorable optimistic 캐시 동작을 검증했습니다.

### Testing
- 포맷: `pnpm format`을 실행했고 성공했습니다.
- 빌드: `pnpm build`을 실행했고 성공했습니다.
- 린트: `pnpm lint`을 실행했고 성공했습니다.
- 테스트: `pnpm test` (또는 패키지 필터로 `pnpm --filter @rs485-homenet/core test`)을 실행해 모든 관련 테스트가 통과했습니다, 포함된 회귀 테스트 `packages/core/test/state/state-persistence.test.ts`의 새 케이스들도 성공했습니다.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f3379dcec832caaa84c2dd082a810)