### PR TITLE
fix(service): use resolveSecurePath for config file resolution in entities routes

### DIFF
--- a/packages/service/src/routes/entities.routes.ts
+++ b/packages/service/src/routes/entities.routes.ts
@@ -23,6 +23,7 @@ import {
   findConfigIndexForEntity,
   findBridgeForEntity,
 } from '../utils/config-helpers.js';
+import { resolveSecurePath } from '../utils/helpers.js';
 
 export interface EntitiesRoutesContext {
   configRateLimiter: RateLimiter;
@@ -138,7 +139,10 @@ export function createEntitiesRoutes(ctx: EntitiesRoutesContext): Router {
     const targetConfigFile = currentConfigFiles[configIndex];
 
     try {
-      const configPath = path.join(ctx.configDir, targetConfigFile);
+      const configPath = resolveSecurePath(ctx.configDir, targetConfigFile);
+      if (!configPath) {
+        return res.status(404).json({ error: 'Config file not found' });
+      }
       const fileContent = await fs.readFile(configPath, 'utf8');
       const loadedYamlFromFile = yaml.load(fileContent) as {
         homenet_bridge: PersistableHomenetBridgeConfig;
@@ -233,7 +237,10 @@ export function createEntitiesRoutes(ctx: EntitiesRoutesContext): Router {
     const targetConfigFile = currentConfigFiles[configIndex];
 
     try {
-      const configPath = path.join(ctx.configDir, targetConfigFile);
+      const configPath = resolveSecurePath(ctx.configDir, targetConfigFile);
+      if (!configPath) {
+        return res.status(404).json({ error: 'Config file not found' });
+      }
       const fileContent = await fs.readFile(configPath, 'utf8');
       const loadedYamlFromFile = yaml.load(fileContent) as {
         homenet_bridge: PersistableHomenetBridgeConfig;
@@ -367,7 +374,10 @@ export function createEntitiesRoutes(ctx: EntitiesRoutesContext): Router {
     const targetConfigFile = currentConfigFiles[configIndex];
 
     try {
-      const configPath = path.join(ctx.configDir, targetConfigFile);
+      const configPath = resolveSecurePath(ctx.configDir, targetConfigFile);
+      if (!configPath) {
+        return res.status(404).json({ error: 'Config file not found' });
+      }
       const fileContent = await fs.readFile(configPath, 'utf8');
       const loadedYamlFromFile = yaml.load(fileContent) as {
         homenet_bridge: PersistableHomenetBridgeConfig;


### PR DESCRIPTION
## Summary
- Replace insecure `path.join` with `resolveSecurePath` when resolving `targetConfigFile` in `entities.routes.ts`.
- Add 404 response handling if the resolved path is outside the configuration directory.

## Details
In `packages/service/src/routes/entities.routes.ts`, `path.join(ctx.configDir, targetConfigFile)` was used in three endpoints. Although `targetConfigFile` is obtained from memory indices, using `resolveSecurePath` enforces defense-in-depth and aligns with the existing pattern in `config.routes.ts` and `gallery.routes.ts`.

Updated endpoints:
- `POST /entities/rename`
- `POST /entities/toggle`
- `GET /entities/:entityId`

## Verification
- Unit tests: `pnpm exec vitest run packages/service` passed (20 test files, 125 tests).
- Formatting: `pnpm format` executed.
