### PR TITLE
Matter FanControl: speed reactor 오프라인 처리, Step 명령 구현 및 낙관적 상태 업데이트

### DIFF
--- a/packages/core/src/transports/matter/behaviors/fan-control-server.ts
+++ b/packages/core/src/transports/matter/behaviors/fan-control-server.ts
@@ -13,12 +13,13 @@ export class FanControlServer extends FeaturedBase {
     const homenet = await this.agent.load(HomenetEntityBehavior);
     this.update(homenet.entityState);
     this.reactTo(homenet.onChange, this.update, { offline: true });
-    this.reactTo(this.events.speedSetting$Changed, this.targetSpeedSettingChanged);
+    this.reactTo(this.events.speedSetting$Changed, this.targetSpeedSettingChanged, {
+      offline: true,
+    });
   }
 
-  private update(entityState: any) {
-    const homenet = this.agent.get(HomenetEntityBehavior);
-    const config = homenet.entityConfig as any;
+  private update(entityState: any, entityConfig?: any) {
+    const config = entityConfig ?? (this.agent.get(HomenetEntityBehavior).entityConfig as any);
 
     // Default steps is 3 (Low, Med, High)
     const speedMax = config.speed_range_max ?? 3;
@@ -59,31 +60,53 @@ export class FanControlServer extends FeaturedBase {
     });
   }
 
+  override async step(request: FanControl.StepRequest) {
+    const speedMax = this.state.speedMax ?? 3;
+    const lowestSpeed = request.lowestOff ? 0 : 1;
+    const currentSpeed = this.state.speedSetting ?? this.state.speedCurrent ?? 0;
+    const direction = request.direction;
+
+    let nextSpeed =
+      direction === FanControl.StepDirection.Increase ? currentSpeed + 1 : currentSpeed - 1;
+
+    if (request.wrap) {
+      if (nextSpeed > speedMax) {
+        nextSpeed = lowestSpeed;
+      } else if (nextSpeed < lowestSpeed) {
+        nextSpeed = speedMax;
+      }
+    } else {
+      nextSpeed = Math.min(speedMax, Math.max(lowestSpeed, nextSpeed));
+    }
+
+    await this.targetSpeedSettingChanged(nextSpeed);
+  }
+
   private async targetSpeedSettingChanged(speed: number | null) {
     if (speed == null) return;
     const homenet = await this.agent.load(HomenetEntityBehavior);
-    const config = homenet.entityConfig as any;
+    const config = { ...(homenet.entityConfig as any) };
+    const entityId = homenet.entityId;
     const speedMax = config.speed_range_max ?? 3;
 
-    try {
-      // If target speed is 0, turn off the fan
-      if (speed === 0) {
-        await homenet.executeCommand(homenet.entityId, 'off');
-        return;
-      }
+    // If target speed is 0, turn off the fan
+    if (speed === 0) {
+      await homenet.executeCommand(entityId, 'off');
+      this.update({ state: 'OFF', speed: 0 }, config);
+      return;
+    }
 
-      // Determine command mapping:
-      // If the entity supports 'speed' command, send the speed number directly or map to percentage.
-      // If fan uses percentage:
-      const hasPercentage = config.command_percentage || config.state_percentage;
-      if (hasPercentage) {
-        const percent = Math.round((speed / speedMax) * 100);
-        await homenet.executeCommand(homenet.entityId, 'percentage', percent);
-      } else {
-        await homenet.executeCommand(homenet.entityId, 'speed', speed);
-      }
-    } finally {
-      this.update(homenet.entityState);
+    // Determine command mapping:
+    // If the entity supports 'speed' command, send the speed number directly or map to percentage.
+    // If fan uses percentage:
+    const hasPercentage = config.command_percentage || config.state_percentage;
+    if (hasPercentage) {
+      const percent = Math.round((speed / speedMax) * 100);
+      await homenet.executeCommand(entityId, 'percentage', percent);
+      this.update({ state: 'ON', percentage: percent }, config);
+    } else {
+      await homenet.executeCommand(entityId, 'speed', speed);
+      this.update({ state: 'ON', speed }, config);
     }
   }
 }

--- a/packages/core/test/transports/matter/behaviors/fan-control-server.test.ts
+++ b/packages/core/test/transports/matter/behaviors/fan-control-server.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FanControl } from '@matter/main/clusters';
+import { FanControlServer } from '../../../../src/transports/matter/behaviors/fan-control-server.js';
+import { HomenetEntityBehavior } from '../../../../src/transports/matter/behaviors/homenet-entity-behavior.js';
+
+vi.mock('../../../../src/transports/matter/behaviors/homenet-entity-behavior.js', () => ({
+  HomenetEntityBehavior: class {
+    static id = 'homenetEntity';
+  },
+}));
+
+vi.mock('../../../../src/transports/matter/utils/apply-patch-state.js', () => ({
+  applyPatchState: vi.fn((state, patch) => {
+    Object.assign(state, patch);
+  }),
+}));
+
+describe('FanControlServer', () => {
+  let server: any;
+  let mockHomenet: any;
+  let reactToFn: any;
+  let state: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    state = {};
+    reactToFn = vi.fn();
+    mockHomenet = {
+      entityConfig: {
+        id: 'room_1_ventilation',
+        speed_range_min: 1,
+        speed_range_max: 3,
+        command_speed: [],
+      },
+      entityState: { state: 'ON', speed: 2 },
+      onChange: {},
+      entityId: 'room_1_ventilation',
+      executeCommand: vi.fn().mockResolvedValue({ success: true }),
+    };
+
+    const AgentMock = class {
+      async load(Behavior: any) {
+        if (Behavior === HomenetEntityBehavior) return mockHomenet;
+        return null;
+      }
+      get(Behavior: any) {
+        if (Behavior === HomenetEntityBehavior) return mockHomenet;
+        return null;
+      }
+    };
+    const agent = new AgentMock();
+
+    server = Object.create(FanControlServer.prototype);
+    Object.defineProperty(server, 'state', { get: () => state });
+    Object.defineProperty(server, 'agent', { get: () => agent });
+    Object.defineProperty(server, 'events', {
+      get: () => ({ speedSetting$Changed: { name: 'speedSetting$Changed' } }),
+    });
+    server.reactTo = reactToFn;
+
+    const origInit = server.initialize;
+    server.initialize = async function () {
+      const baseProto = Object.getPrototypeOf(Object.getPrototypeOf(this));
+      const oldInit = baseProto.initialize;
+      baseProto.initialize = async () => {};
+      try {
+        await origInit.call(this);
+      } finally {
+        baseProto.initialize = oldInit;
+      }
+    };
+  });
+
+  it('Homenet 상태 변경과 Matter 목표 풍량 변경을 모두 offline reactor로 등록한다', async () => {
+    await server.initialize();
+
+    expect(reactToFn).toHaveBeenCalledWith(mockHomenet.onChange, expect.any(Function), {
+      offline: true,
+    });
+    expect(reactToFn).toHaveBeenCalledWith({ name: 'speedSetting$Changed' }, expect.any(Function), {
+      offline: true,
+    });
+  });
+
+  it('기존 MQTT fan 속도 범위 1~3 설정을 Matter FanControl 상태로 매핑한다', async () => {
+    await server.initialize();
+
+    expect(state.speedMax).toBe(3);
+    expect(state.speedSetting).toBe(2);
+    expect(state.speedCurrent).toBe(2);
+    expect(state.fanMode).toBe(FanControl.FanMode.On);
+    expect(state.fanModeSequence).toBe(FanControl.FanModeSequence.OffLowMedHigh);
+  });
+
+  it('Matter 목표 풍량 변경 시 command_speed 명령을 실행하고 만료될 수 있는 Homenet state를 재참조하지 않는다', async () => {
+    await server.initialize();
+    mockHomenet.executeCommand.mockImplementationOnce(async () => {
+      Object.defineProperty(mockHomenet, 'entityState', {
+        get: () => {
+          throw new Error('ExpiredReferenceError');
+        },
+      });
+      return { success: true };
+    });
+
+    await server.targetSpeedSettingChanged(3);
+
+    expect(mockHomenet.executeCommand).toHaveBeenCalledWith('room_1_ventilation', 'speed', 3);
+    expect(state.speedSetting).toBe(3);
+    expect(state.speedCurrent).toBe(3);
+    expect(state.fanMode).toBe(FanControl.FanMode.On);
+  });
+
+  it('Matter step 명령을 다음 풍량으로 변환한다', async () => {
+    await server.initialize();
+
+    await server.step({ direction: FanControl.StepDirection.Increase });
+
+    expect(mockHomenet.executeCommand).toHaveBeenCalledWith('room_1_ventilation', 'speed', 3);
+    expect(state.speedSetting).toBe(3);
+  });
+
+  it('Matter step 명령에서 lowestOff와 wrap을 지원한다', async () => {
+    mockHomenet.entityState = { state: 'OFF', speed: 0 };
+    await server.initialize();
+
+    await server.step({
+      direction: FanControl.StepDirection.Decrease,
+      lowestOff: true,
+      wrap: true,
+    });
+
+    expect(mockHomenet.executeCommand).toHaveBeenCalledWith('room_1_ventilation', 'speed', 3);
+    expect(state.speedSetting).toBe(3);
+  });
+
+  it('Matter 목표 풍량 0은 fan off 명령으로 변환한다', async () => {
+    await server.initialize();
+
+    await server.targetSpeedSettingChanged(0);
+
+    expect(mockHomenet.executeCommand).toHaveBeenCalledWith('room_1_ventilation', 'off');
+    expect(state.speedSetting).toBe(0);
+    expect(state.speedCurrent).toBe(0);
+    expect(state.fanMode).toBe(FanControl.FanMode.Off);
+  });
+});


### PR DESCRIPTION
### Motivation
- Matter로 매핑되는 환기(Fan) 장치에서 풍량 변경 처리 중 동기/비동기 트랜잭션 충돌로 인해 Reactor 오류와 ExpiredReferenceError가 발생하여 브리지가 종료되는 문제를 방지하기 위해 변경했습니다.

### Description
- `speedSetting$Changed` 리액터를 오프라인 트랜잭션으로 등록해 동기 Observable 컨텍스트에서 비동기 명령 실행이 문제를 일으키지 않도록 했습니다 (`packages/core/src/transports/matter/behaviors/fan-control-server.ts`).
- 비동기 명령 실행 시 `homenet.entityState`를 다시 읽어 만료된 참조(ExpiredReferenceError)에 접근하지 않도록, `entityConfig`와 `entityId`를 캡처하고 명령 수행 후 낙관적(optimistic) Matter 상태를 적용하도록 수정했습니다 (`targetSpeedSettingChanged`에서 상태 업데이트 적용).
- Matter FanControl의 `Step` 명령을 구현하여 Increase/Decrease, `wrap`, `lowestOff` 옵션을 기존 `speed`/`off` 명령으로 변환하도록 추가했습니다 (`FanControlServer.step` 구현).
- 위 동작을 검증하는 회귀 테스트를 추가했습니다 (`packages/core/test/transports/matter/behaviors/fan-control-server.test.ts`).

### Testing
- `pnpm format`를 실행하여 코드 포맷을 적용했고 성공했습니다.
- `pnpm build`를 실행하여 패키지 빌드가 정상 완료됨을 확인했습니다.
- `pnpm lint`를 실행하여 타입/정적 검사 통과를 확인했습니다.
- 단위/통합 테스트: `pnpm test` 및 개별 테스트 파일(`packages/core/test/transports/matter/behaviors/fan-control-server.test.ts`)을 포함한 전체 테스트 스위트가 모두 통과했습니다 (추가된 FanControlServer 테스트 포함, 모든 관련 테스트 성공).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8323673f3c832c8b8d8b7d651bb8e8)