### PR TITLE
Optimize xor_final checksum in PacketParser sliding window

### DIFF
--- a/packages/core/src/protocol/packet-parser.ts
+++ b/packages/core/src/protocol/packet-parser.ts
@@ -45,6 +45,7 @@ export class PacketParser {
   private validHeaderCount: number = 0;
   private isStandard1Byte: boolean = false;
   private isStandard2Byte: boolean = false;
+  private xorFinalValue: number | null = null;
 
   // Optimized checksum function (bypasses switch/call overhead)
   private checksumFn: ((buffer: ByteArray, start: number, end: number) => number) | null = null;
@@ -123,6 +124,13 @@ export class PacketParser {
       typeof checksumType === 'string' &&
       !this.isChecksumNone &&
       PacketParser.CHECKSUM_TYPES.has(checksumType);
+
+    if (typeof checksumType === 'string') {
+      const xorFinalMatch = /^xor_final(?:_no_header)?\(0x([0-9a-fA-F]{2})\)$/.exec(checksumType);
+      if (xorFinalMatch) {
+        this.xorFinalValue = Number.parseInt(xorFinalMatch[1], 16);
+      }
+    }
 
     // Bolt: Pre-resolve checksum function
     if (this.isStandard1Byte) {
@@ -334,7 +342,7 @@ export class PacketParser {
           // Threshold 16 is empirically determined (256/16 = 16x skips per match).
           const useSparseScan = this.validHeaderCount > 0 && this.validHeaderCount < 16;
 
-          if (!useSparseScan && this.isStandard1Byte && !isBestinSum && !typeStr.startsWith('xor_final(') && !typeStr.startsWith('xor_final_no_header(')) {
+          if (!useSparseScan && this.isStandard1Byte && !isBestinSum) {
             useSlidingWindow = true;
             const isNoHeader =
               typeStr.includes('no_header') || isSamsungRx || isSamsungTx || isSamsungXor;
@@ -446,6 +454,8 @@ export class PacketParser {
                   }
                 } else if (isSamsungXor) {
                   finalChecksum &= 0x7f;
+                } else if (this.xorFinalValue !== null) {
+                  finalChecksum ^= this.xorFinalValue;
                 }
 
                 const expected = this.buffer[currentOffset + checksumIndexRel];
@@ -608,6 +618,8 @@ export class PacketParser {
                 }
               } else if (isSamsungXor) {
                 finalChecksum &= 0x7f;
+              } else if (this.xorFinalValue !== null) {
+                finalChecksum ^= this.xorFinalValue;
               }
 
               const expected = this.buffer[baseOffset + len - 1 - footerLen];
@@ -858,6 +870,8 @@ export class PacketParser {
                 }
               } else if (isSamsungXor) {
                 finalChecksum &= 0x7f;
+              } else if (this.xorFinalValue !== null) {
+                finalChecksum ^= this.xorFinalValue;
               }
 
               const expected = this.buffer[baseOffset + len - 1];

--- a/packages/core/src/protocol/utils/checksum.ts
+++ b/packages/core/src/protocol/utils/checksum.ts
@@ -2,11 +2,13 @@ import type { ChecksumType, Checksum2Type } from '../types.js';
 
 export type { ChecksumType, Checksum2Type };
 
-const XOR_FINAL_TYPES = Array.from({ length: 256 }, (_, value) =>
-  `xor_final(0x${value.toString(16).padStart(2, '0')})`,
+const XOR_FINAL_TYPES = Array.from(
+  { length: 256 },
+  (_, value) => `xor_final(0x${value.toString(16).padStart(2, '0')})`,
 ) as ChecksumType[];
-const XOR_FINAL_NO_HEADER_TYPES = Array.from({ length: 256 }, (_, value) =>
-  `xor_final_no_header(0x${value.toString(16).padStart(2, '0')})`,
+const XOR_FINAL_NO_HEADER_TYPES = Array.from(
+  { length: 256 },
+  (_, value) => `xor_final_no_header(0x${value.toString(16).padStart(2, '0')})`,
 ) as ChecksumType[];
 
 export const STANDARD_CHECKSUM_TYPES = [
@@ -310,7 +312,8 @@ export function calculateChecksumFromBuffer(
   const resolved = resolveChecksumType(type);
   if (resolved.kind === 'xor_final') {
     return (
-      xorRange(buffer, resolved.includeHeader ? dataStart : headerStart, dataStop) ^ resolved.finalXor
+      xorRange(buffer, resolved.includeHeader ? dataStart : headerStart, dataStop) ^
+      resolved.finalXor
     );
   }
   if (resolved.kind === 'crc8') {

--- a/packages/core/test/packet-parser/xor-final-checksum.test.ts
+++ b/packages/core/test/packet-parser/xor-final-checksum.test.ts
@@ -47,4 +47,65 @@ describe('PacketParser xor_final checksum', () => {
     const packet = Buffer.from([0xaa, 0x01, 0x02, 0x57]);
     expect(parser.parseChunk(packet)).toHaveLength(0);
   });
+
+  it('correctly handles sliding-window shifts with noise and multiple offsets', () => {
+    const parser = new PacketParser({
+      rx_header: [0xaa],
+      rx_length: 4,
+      rx_checksum: 'xor_final(0x55)',
+    });
+
+    // Packet 1: AA 01 02 FC
+    // Packet 2: AA 03 04 F8 (AA ^ 03 ^ 04 ^ 55 = F8)
+    // Stream with noise: [0x12, 0x34, 0xAA, 0x01, 0x02, 0xFC, 0x99, 0xAA, 0x03, 0x04, 0xF8]
+    const chunk = Buffer.from([0x12, 0x34, 0xaa, 0x01, 0x02, 0xfc, 0x99, 0xaa, 0x03, 0x04, 0xf8]);
+
+    const result = parser.parseChunk(chunk);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual(Buffer.from([0xaa, 0x01, 0x02, 0xfc]));
+    expect(result[1]).toEqual(Buffer.from([0xaa, 0x03, 0x04, 0xf8]));
+  });
+
+  it('correctly handles sliding-window shifts with xor_final_no_header and noise', () => {
+    const parser = new PacketParser({
+      rx_header: [0xaa],
+      rx_length: 4,
+      rx_checksum: 'xor_final_no_header(0x55)',
+    });
+
+    // Packet 1: AA 01 02 56 (01 ^ 02 ^ 55 = 56)
+    // Packet 2: AA 03 04 52 (03 ^ 04 ^ 55 = 52)
+    // Stream with noise: [0xFE, 0xAA, 0x01, 0x02, 0x56, 0xAA, 0x03, 0x04, 0x52]
+    const chunk = Buffer.from([0xfe, 0xaa, 0x01, 0x02, 0x56, 0xaa, 0x03, 0x04, 0x52]);
+
+    const result = parser.parseChunk(chunk);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual(Buffer.from([0xaa, 0x01, 0x02, 0x56]));
+    expect(result[1]).toEqual(Buffer.from([0xaa, 0x03, 0x04, 0x52]));
+  });
+
+  it('parses footer-delimited frames with xor_final(0x55)', () => {
+    const parser = new PacketParser({
+      rx_header: [0xaa],
+      rx_footer: [0x0d, 0x0a],
+      rx_checksum: 'xor_final(0x55)',
+    });
+
+    // Packet: AA 01 02 FC 0D 0A
+    // Checksum byte is FC (AA ^ 01 ^ 02 ^ 55 = FC)
+    const packet = Buffer.from([0xaa, 0x01, 0x02, 0xfc, 0x0d, 0x0a]);
+    expect(parser.parseChunk(packet)).toEqual([packet]);
+  });
+
+  it('parses variable-length / rx_length_expr frames with xor_final(0x55)', () => {
+    const parser = new PacketParser({
+      rx_header: [0xaa],
+      rx_length_expr: '5',
+      rx_checksum: 'xor_final(0x55)',
+    });
+
+    // Length = 5: AA 01 02 03 FF (AA ^ 01 ^ 02 ^ 03 ^ 55 = FF)
+    const packet = Buffer.from([0xaa, 0x01, 0x02, 0x03, 0xff]);
+    expect(parser.parseChunk(packet)).toEqual([packet]);
+  });
 });

--- a/packages/core/test/protocol/checksum_utils.test.ts
+++ b/packages/core/test/protocol/checksum_utils.test.ts
@@ -24,7 +24,7 @@ describe('Checksum Utils', () => {
     it('should support parameterized xor_final()', () => {
       const fn = getChecksumFunction('xor_final(0x55)' as any);
       expect(fn).toBeDefined();
-      expect(fn!([0x01, 0x02, 0x03], 0, 3)).toBe((0x01 ^ 0x02 ^ 0x03) ^ 0x55);
+      expect(fn!([0x01, 0x02, 0x03], 0, 3)).toBe(0x01 ^ 0x02 ^ 0x03 ^ 0x55);
     });
 
     it('should support all byte-sized xor_final values', () => {


### PR DESCRIPTION
This change integrates xor_final(0xNN) and xor_final_no_header(0xNN) checksum handling directly into PacketParser's O(1) sliding-window optimization path.

Key changes:
1. Parsed and cached xorFinalValue in PacketParser constructor for xor_final checksum types.
2. Removed xor_final bypass check from Strategy A (fixed length) sliding-window optimization.
3. Applied xorFinalValue during the final checksum evaluation step across Strategy A, Strategy B, and Strategy C without affecting leavingByte/enteringByte window shifts.
4. Added test cases in xor-final-checksum.test.ts covering fixed-length packets, invalid checksum rejection, sliding-window shifts with stream noise across multiple offsets, footer-delimited frames, and variable-length parsing.

---
*PR created automatically by Jules for task [17991504305377586766](https://jules.google.com/task/17991504305377586766) started by @wooooooooooook*