### PR TITLE
docs: standardize ChatGPT PR workspace artifact flow

### DIFF
--- a/.agents/skills/luna-chat-coder/SKILL.md
+++ b/.agents/skills/luna-chat-coder/SKILL.md
@@ -1,143 +1,130 @@
 ---
 name: luna-chat-coder
-description: Keep repository development reliable from chat by using the sandbox work container first, recovering exact GitHub state, and using bounded Actions missions when normal sandbox or GitHub paths are insufficient.
+description: Keep repository development reliable from chat by using the repository's ChatGPT workspace artifact flow for PR work, with sandbox-first execution after exact source materialization and bounded Actions fallback when needed.
 license: MIT
-compatibility: Requires access to durable repository state. The fully specified ChatGPT Web path requires both the GitHub Plugin and the ChatGPT Codex Connector GitHub App for the target repository. GitHub Actions access is required only when an Actions mission is needed. Other Agent Skills hosts may use the core policy only to the extent that equivalent capabilities actually exist.
+compatibility: Requires access to durable repository state. The ChatGPT Web PR path uses the GitHub Plugin and the repository's package-chat-workspace workflow. Other Agent Skills hosts may use the core policy only to the extent that equivalent capabilities exist.
 metadata:
-  version: "0.1.0"
+  version: "0.2.0"
 ---
 
 # Luna Chat Coder
 
-Luna Chat Coder is a repository-development continuity and fallback policy for ordinary chat. Discover it early, keep it quiet on the normal path, and activate fallback mechanisms only when the normal sandbox or connected GitHub path becomes insufficient.
+Luna Chat Coder is the repository-development policy for substantial work initiated from chat. It provides a deterministic handoff from GitHub to the chat sandbox and preserves exact source identity throughout the PR lifecycle.
 
 ## Canonical terms
 
-Use these terms consistently:
-
-- **sandbox work container**: the isolated, disposable code-execution container attached to the current chat surface. In ChatGPT Web, this means the ChatGPT sandbox work container. Treat it as the primary development workstation, not as the user's computer.
-- **durable repository state**: exact GitHub state such as a commit, PR head, branch/ref plus its resolved commit SHA, or an immutable repository/Actions artifact.
-- **Actions mission**: a bounded GitHub Actions execution used when the normal sandbox or connected GitHub path cannot safely or efficiently provide a required capability, exact transport, or execution step. It has explicit inputs, expected source identity, defined outputs, and a terminal lifecycle. It is not an interactive remote shell.
-- **degraded remote mode**: the exceptional case where the sandbox work container itself cannot sustain the requested engineering work and a sequence of bounded Actions missions temporarily performs edit/build/test execution instead.
+- **sandbox work container**: the isolated, disposable code-execution environment attached to the chat. It is the primary editing, testing, and debugging workstation after the exact workspace has been materialized.
+- **chat-workspace artifact**: the `chat-workspace` GitHub Actions artifact produced by `.github/workflows/package-chat-workspace.yml`. It is the canonical source transport for ChatGPT PR work in this repository.
+- **durable repository state**: an exact commit, PR head, branch/ref resolved to a commit SHA, or immutable Actions artifact.
+- **Actions mission**: a bounded GitHub Actions execution used for a specific capability, transport, or execution gap. It is not an interactive remote shell.
 
 Do not use `local container`, `local environment`, or `bridge` for these concepts.
 
 ## Core invariants
 
-1. **Discover early, activate late.** Load this policy before substantial repository work, but do not use Actions merely because the skill is present.
-2. **Materialize exact source before editing.** When a target GitHub repository is given, resolve the intended commit or PR-head SHA and establish a complete working tree for that exact state inside the sandbox before source edits, builds, tests, or iterative debugging. Inspect surviving sandbox work before replacing it. Prefer normal Git clone/fetch/checkout when the sandbox can reach the repository; otherwise use another exact repository read/archive transport that preserves the required files and identity. Verify the materialized state corresponds to the expected SHA before modifying it.
-3. **Sandbox first.** Prefer the sandbox work container for source inspection, editing, building, testing, linting, formatting, running services, and iterative debugging once the exact target source has been materialized there.
-4. **Inventory before acquiring.** Inspect capabilities already present in the sandbox before installing, downloading, or dispatching a mission.
-5. **The repository defines the engineering method.** Infer required runtimes, services, databases, browsers, compilers, test tools, and versions from repository declarations and task requirements. Do not introduce substitutes or a new methodology on Luna's behalf.
-6. **GitHub holds exact durable truth.** Chat is useful for intent; conversation reconstruction is not a substitute for exact source when durable source exists. Keep observed repository facts distinct from material assumptions.
-7. **Durable handoff is task-owned.** Use a branch, PR, issue, commit, or task-owned artifact when losing state would make recovery expensive or ambiguous; keep cheap intermediate reasoning in chat.
-8. **Assume concurrent actors.** Other chats, agents, CI, or humans may create or move branches, refs, commits, workflows, and artifacts while this task is active. Resolve mutable names to current immutable identity before writes, publication, or cleanup; preserve unfamiliar state and never infer ownership from age or naming alone.
-9. **Choose the simplest reliable exact path.** File writes, native Git object operations, and patch/bundle missions are transport choices, not a rigid hierarchy. Select using exactness, payload shape, file count, round trips, integration limits, and observed reliability.
-10. **Diagnose before retrying.** Inspect returned errors or Actions logs/results before changing source or repeating an operation. Do not guess a root cause from failure status alone.
-11. **The user's host computer is outside the workflow.** Do not require direct access to it or ask the user to weaken host isolation merely to unblock ordinary repository development.
-12. **Evidence bounds completion claims.** Report only operations and checks that actually ran against the relevant state.
+1. **Discover early, activate late.** Read this skill before substantial repository work. Do not use unrelated Actions missions merely because this skill is present.
+2. **PR work starts with the workspace workflow.** For ChatGPT-initiated PR work in this repository, create/use a task-owned branch and make the prescribed `package-chat-workspace.yml` comment change as the first PR-workflow handoff. Push that workflow change so the exact branch commit is packaged.
+3. **Materialize exact source before editing.** Download the resulting `chat-workspace` artifact and reconstruct the complete repository workspace in the sandbox before source edits, builds, tests, or iterative debugging. Verify `SOURCE-IDENTITY.txt`, checksums, and manifest, and confirm the extracted source corresponds to the packaged commit SHA.
+4. **Artifact source is authoritative for the editing phase.** Do not reconstruct repository source from conversation snippets, partial API reads, or remembered content once the artifact is available.
+5. **Sandbox first after materialization.** Prefer the extracted workspace for editing, builds, tests, linting, formatting, services, and debugging.
+6. **The repository defines the engineering method.** Follow repository runtimes, package manager, dependencies, architecture, build system, and verification requirements. Do not introduce substitutes merely for convenience.
+7. **GitHub holds durable truth.** Keep exact branch, PR, and commit identity separate from chat intent. Resolve mutable refs to immutable SHAs before important writes.
+8. **Preserve unrelated work.** Never overwrite or silently discard unfamiliar changes in the workspace or task branch.
+9. **Diagnose before retrying.** Inspect errors, workflow logs, artifacts, and resulting state before changing source or repeating a failed operation.
+10. **User host is outside the workflow.** Do not require direct access to the user's computer or ask the user to weaken host isolation.
+11. **Completion claims require evidence.** Report only checks and publication steps that actually ran against the relevant state.
 
-## Silent readiness preflight
+## Canonical ChatGPT PR workflow
 
-Before substantial work, perform the smallest useful preflight without making the user operate a checklist:
+Use this sequence whenever the user asks to start or perform substantial PR work from ChatGPT:
 
-1. identify the repository, task/PR if any, and expected commit SHA when available;
-2. inspect any surviving sandbox workspace before replacing or merging it;
-3. resolve the intended mutable branch/PR name to its current immutable commit SHA;
-4. materialize that exact repository state as a complete sandbox working tree and verify it matches the expected SHA before editing;
-5. read the repository declarations needed to understand runtime, dependency, service, build, and test requirements;
-6. inventory the sandbox capabilities already available;
-7. determine which connected repository read/write and Git object operations are available;
-8. determine whether Actions/workflow/log/artifact operations are available if a fallback later becomes necessary.
+```text
+1. Resolve repository + requested task/PR + current base/head identity.
+2. Create or select a task-owned branch.
+3. Modify only the prescribed comment in .github/workflows/package-chat-workspace.yml.
+4. Push that workflow change.
+5. Wait for the package-chat-workspace Actions run to complete.
+6. Retrieve the chat-workspace artifact.
+7. Verify SOURCE-IDENTITY.txt, SHA256SUMS, and MANIFEST.txt.
+8. Extract source.tar.gz and, when useful, restore pnpm-store.tar.gz.
+9. Confirm extracted source == packaged commit SHA.
+10. Perform all repository edits in the extracted sandbox workspace.
+11. Run formatting, tests, builds, and other repository-required checks.
+12. Inspect the complete diff and verify no unrelated changes were introduced.
+13. Publish the resulting exact changes back to the task branch/PR.
+14. Reconcile the published branch/PR SHA with the edited workspace and report validation.
+```
 
-When the normal path is healthy, do not narrate this preflight to the user.
+The initial workflow-comment change is intentional. It provides a deterministic GitHub Actions trigger and establishes a durable source package for the branch before iterative editing begins. Do not treat that comment as application functionality.
 
-## Work in the sandbox first
+The packaging workflow excludes itself from `source.tar.gz`; therefore the extracted editing workspace contains the repository source as it existed for the triggering commit without recursively packaging the transport workflow. Preserve the workflow change separately when publishing the final PR state.
 
-Treat the sandbox work container as a disposable development workstation. For a repository task, first recover or materialize the exact target commit/PR-head source into a complete working tree there, verify its identity, and only then perform source edits or the engineering loop. A handful of repository API reads is not a substitute for establishing the working tree when the task requires editing, building, testing, or inspecting repository-wide behavior.
+## Artifact integrity and provenance
 
-When ordinary Git network access is available, clone/fetch and check out the resolved target state. If the sandbox cannot reach GitHub directly but connected repository reads or an exact archive/transport are available, use those to reconstruct the complete target tree without inventing bytes. If no exact source path can establish the required working tree, treat that as a capability/transport gap rather than editing an incomplete reconstruction.
+The package workflow records repository, commit SHA, ref, workflow name, and run ID. It also emits `SHA256SUMS` and `MANIFEST.txt`. Treat these as a provenance and integrity contract, not optional documentation.
 
-When the repository requires a capability that is absent, first try a safe and faithful sandbox setup if the environment permits it. Installation and configuration choices that are purely disposable development details can be resolved autonomously when the requested outcome is clear.
+Before editing:
 
-Do not silently weaken verification because setup is inconvenient. If the repository requires a real integration for the behavior under test, prefer that integration over an easier substitute.
+1. verify the artifact belongs to the expected repository and task branch;
+2. verify the packaged commit SHA is the intended durable source;
+3. verify archive/chunk checksums before extraction;
+4. reconstruct any split archive without changing bytes;
+5. inspect the resulting tree and confirm its Git identity where possible.
 
-## Use Actions missions when they reduce real risk or cost
+If the branch moved before editing or publication, stop and reconcile the new commit intentionally. Do not apply a verified change blindly to a different base.
 
-An Actions mission is appropriate when at least one of these is true:
+## Publishing changes from the artifact workspace
 
-- the sandbox cannot obtain or execute a repository-required capability;
-- the sandbox itself is unavailable or cannot sustain the task;
-- a substantial exact patch/bundle is safer or more efficient than repeated per-file writes;
-- the connected GitHub write path is constrained by payload/operation limits or is observably unstable after its returned errors have been inspected;
-- binary changes, renames, mode changes, Git history, or another payload property is better preserved as one deterministic transport unit.
+The artifact is a source transport, not a publication authority. After editing:
 
-Do not dispatch a mission merely because Actions exists. Do not abandon a connected GitHub path after one unexplained failure: inspect the error first. A clearly transient operation may be retried once when safe; repeated or structurally brittle failures are a reason to choose a different exact transport.
+- preserve exact source bytes and Git semantics whenever possible;
+- use local Git or connected Git object/file operations according to the repository's available tooling;
+- prefer a single exact patch/bundle or native Git tree/commit operation when many files, renames, modes, binaries, or repeated writes make per-file publication brittle;
+- inspect the resulting remote diff and commit SHA after publication;
+- do not recreate substantial edits from prose after a transport failure when the verified workspace or patch still exists.
 
-The common capability case is a **supply mission**: a networked runner obtains or prepares a required dependency, runtime, SDK, compiler, native library, generated input, cache, archive, or other external build input and returns a verified artifact. After the missing capability is supplied, return to the sandbox engineering loop.
+If publication reveals a mismatch, consider the transport itself as a possible source of byte drift before assuming the edited workspace is wrong.
 
-### Distinguish acquisition gaps from execution gaps
+## Sandbox and dependency setup
 
-If the sandbox can faithfully execute a required capability once the necessary bytes are available, prefer a supply mission that obtains or prepares those bytes and returns them to the sandbox. Do not move the engineering loop to Actions merely because the sandbox cannot download or initially install a required tool or service.
+Inventory capabilities before installing anything. If the repository requires dependencies that the sandbox cannot obtain but can execute once supplied, use a bounded supply mission or another faithful transport to obtain the missing bytes, then return to the sandbox.
 
-For example, if the repository requires PostgreSQL and the sandbox can run PostgreSQL but cannot obtain the required packages or distribution, use a supply mission to acquire a compatible PostgreSQL distribution or installation payload, verify it in the sandbox, install and start PostgreSQL there, and continue migrations, application execution, tests, and debugging in the sandbox.
+For this repository, pnpm and its lockfile define the dependency model. Do not replace the package manager with npm/yarn merely to make the task easier.
 
-Use remote execution only when the sandbox cannot faithfully execute the required capability even after the necessary inputs have been supplied, or when the sandbox itself cannot sustain the task.
+Run the repository-defined checks. For this repository, code changes require formatting with `pnpm format` after modification, and Vitest is the test framework unless a narrower task explicitly defines additional checks.
 
-If the sandbox work container itself is unavailable or cannot sustain the task because of platform usage limits, execution-duration limits, resource limits, missing execution capability, or another hard environment constraint, enter **degraded remote mode**. Continue with bounded Actions missions that perform only the necessary editing, build, test, packaging, or verification steps, using GitHub commits/branches/artifacts as durable state between missions.
+## Actions missions and degraded remote mode
 
-Degraded remote mode is a fallback, not the preferred environment. Tell the user in the next meaningful user-visible update or final report that sandbox execution was unavailable or insufficient and that the work continued through GitHub Actions. Do not speculate about billing. If an operation would require an explicitly paid or materially costly resource beyond ordinary configured Actions use, obtain the user's approval before creating that cost.
+Use a separate Actions mission only when the sandbox cannot faithfully provide a required capability, a deterministic transport is materially safer, or the sandbox itself is unavailable/insufficient.
 
-Read [`references/actions-missions.md`](references/actions-missions.md) before dispatching an Actions mission.
+The normal `package-chat-workspace.yml` handoff is **not** a degraded remote mode mission. It is the repository's canonical ChatGPT PR source transport and should be used before editing even when the sandbox is healthy.
 
-## Publish exact changes
+If the sandbox becomes unavailable after artifact acquisition, enter degraded remote mode only as a fallback. Use bounded missions with explicit inputs, outputs, source SHA, checksums, and terminal state. Persist progress as commits, task-owned branches, patches, bundles, or immutable artifacts.
 
-Choose the lowest-overhead path that remains exact and reliable for the observed task:
-
-- connected repository file operations are usually efficient for small textual changes;
-- native Git blob/tree/commit/ref operations can efficiently publish substantial multi-file state when exposed by the integration;
-- an exact patch or bundle carried by an Actions mission can be preferable for large or complex diffs, repeated-write overhead, binary/mode/rename semantics, connector limits, or persistent API instability.
-
-Capture the expected base SHA before substantial publication work. If the base moved, recover the new durable state and deliberately rebase, merge, or recreate the payload. Do not reconstruct a substantial verified change from prose when exact source bytes can be transported.
-
-Model-mediated reconstruction or serialization of publication payloads can introduce unintended byte-level drift even when the intended source is unchanged. When a published file or object differs from the verified source, consider the publication path itself as a possible cause before assuming the source or overall publication strategy is wrong.
-
-If the strategy still appears appropriate, a limited retry of only the failed payload may be reasonable. Preserve the verified source rather than reconstructing it unnecessarily, avoid disturbing outputs that are already known to be correct, and use available integrity evidence to confirm the result when practical. If the failure persists, reassess the transport or report the blocker rather than repeating the same operation blindly.
+Read `references/actions-missions.md` before dispatching a separate Actions mission.
 
 ## Recovery
 
-After a chat reset, sandbox loss, or source-identity ambiguity, read [`references/recovery.md`](references/recovery.md).
-
-Prefer recovery in this order:
+After a chat reset, sandbox loss, or source-identity ambiguity, recover in this order:
 
 ```text
-commit / PR head
-    > immutable Git or Actions artifact
-    > surviving sandbox working tree
+current PR/branch head commit
+    > chat-workspace artifact and its provenance
+    > surviving sandbox workspace
+    > exact patch/bundle
     > conversation reconstruction
 ```
 
-Preserve unfamiliar surviving work and mission state until ownership and terminal status are understood.
+Preserve unfamiliar state until ownership and identity are understood.
+
+If the original package artifact is still the correct source handoff, reuse it instead of generating duplicate transport state.
 
 ## Completion and reporting
 
-Source edits alone are not completion when executable behavior is part of the task. Run the applicable application/services, setup or migrations, build, tests, integration checks, and end-to-end checks required by the repository and task.
+At completion report the exact branch/PR and commit state changed, the exact artifact/source identity used for editing, checks actually run and their results, any check that could not run and the blocker, and whether an additional degraded Actions mission was required.
 
-At completion, report:
-
-- what exact state was changed or published;
-- what checks actually ran and their results;
-- any check that could not run and the exact blocker;
-- whether degraded remote mode was used because the sandbox work container was unavailable or insufficient.
-
-Do not burden the user with Luna-specific mechanics on a healthy normal path.
-
-## Portability boundary
-
-The skill uses the Agent Skills structure and keeps its core policy host-neutral. The repository documents and validates the ChatGPT Web GitHub path explicitly because that path has known GitHub prerequisites.
-
-On another Agent Skills host, use the host's analogous sandboxed code-execution environment and only the repository/Actions capabilities that actually exist and are authorized. Do not infer full support merely because the host can parse `SKILL.md`, and do not invent GitHub write, workflow, log, artifact, or credential access that is not present.
+Do not burden the user with Luna-specific mechanics when the workflow is progressing normally, but do surface a transport or source-identity problem when it affects correctness.
 
 ## Maintaining Luna itself
 
-When the task is to modify, review, or redesign Luna Chat Coder rather than merely use it for another repository task, read [`references/design-rationale.md`](references/design-rationale.md) before changing policy. That document is maintainer memory, not runtime policy; if it conflicts with this `SKILL.md`, reconcile the inconsistency rather than silently treating historical rationale as a current instruction.
+When changing this skill, preserve the repository-specific ChatGPT artifact workflow as the canonical PR handoff unless the repository workflow is deliberately redesigned at the same time. Keep generic Actions fallback policy separate from the normal workspace packaging path.

--- a/.github/workflows/package-chat-workspace.yml
+++ b/.github/workflows/package-chat-workspace.yml
@@ -39,6 +39,7 @@ jobs:
       # That push packages the exact branch commit. Download chat-workspace,
       # extract it locally/sandboxed, edit from that exact source, then publish
       # the resulting changes back to the task branch/PR.
+      # Handoff protocol: source identity + checksums + manifest are mandatory.
       - name: Package repository source
         shell: bash
         run: |

--- a/.github/workflows/package-chat-workspace.yml
+++ b/.github/workflows/package-chat-workspace.yml
@@ -34,10 +34,11 @@ jobs:
             printf 'run_id=%s\n' "$GITHUB_RUN_ID"
           } > workspace-artifacts/SOURCE-IDENTITY.txt
 
-      # Keep this workflow source-compatible with ChatGPT workspace packaging.
-      # When changing repository files through ChatGPT, update this comment and push
-      # to trigger packaging; then retrieve the generated chat-workspace artifact
-      # and use that artifact as the source of truth for subsequent edits/PR updates.
+      # This workflow is the canonical ChatGPT PR workspace transport.
+      # Start a PR by changing this comment and pushing the workflow file.
+      # That push packages the exact branch commit. Download chat-workspace,
+      # extract it locally/sandboxed, edit from that exact source, then publish
+      # the resulting changes back to the task branch/PR.
       - name: Package repository source
         shell: bash
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,11 +19,20 @@ Only after modifying code, run `pnpm format` to format all packages.
 
 # Luna Chat Coder entry point
 
-When substantial repository development is performed from a chat surface with a disposable or sandboxed code-execution environment, read `.agents/skills/luna-chat-coder/SKILL.md` before making substantial changes.
+When substantial repository development is performed from a chat surface, read `.agents/skills/luna-chat-coder/SKILL.md` before making substantial changes.
 
-Loading the skill is a readiness step, not a reason to use GitHub Actions. Normal engineering work should stay in the chat sandbox work container when it is available and sufficient.
+## Chat PR workspace transport
 
-The repository itself defines its runtimes, services, dependencies, architecture, build system, and verification requirements. Luna Chat Coder supplies continuity and missing execution capability; it does not introduce a development methodology or substitute technologies merely because they are easier to run.
+For PR work initiated from ChatGPT, use `.github/workflows/package-chat-workspace.yml` as the canonical source transport:
+
+1. Start the PR work from a task-owned branch and make the required change to `package-chat-workspace.yml` that triggers the workspace packaging workflow.
+2. Push that workflow change so GitHub Actions produces the `chat-workspace` artifact for the exact branch commit.
+3. Download the generated artifact and reconstruct the complete repository workspace locally/sandboxed from that artifact. Treat `SOURCE-IDENTITY.txt`, `SHA256SUMS`, and `MANIFEST.txt` as the provenance and integrity contract.
+4. Make the requested repository edits against that extracted workspace. Do not reconstruct source from chat snippets or partial GitHub file reads when the artifact is available.
+5. Run the repository-defined formatting, tests, builds, and other checks in the extracted workspace as appropriate.
+6. Upload/publish the resulting exact changes back to the task branch/PR using the most reliable exact transport available. Preserve the source commit identity and inspect the final diff before publication.
+
+The workflow is a transport mechanism, not a remote interactive shell. Do not use it merely because it exists; for this repository's ChatGPT PR workflow it is the required handoff path between the initial PR setup and subsequent local/sandbox editing.
 
 Treat exact GitHub commit and PR state as durable source truth, preserve unrelated work, and do not make access to the user's computer a dependency of the workflow.
 


### PR DESCRIPTION
## Summary
- make `package-chat-workspace.yml` the canonical ChatGPT PR workspace handoff
- document artifact-first source materialization in `AGENTS.md`
- update Luna Chat Coder to use the artifact flow before sandbox editing
- record source identity, checksums, and manifest as the handoff contract

## Validation
- verified the updated files and branch state through GitHub
- the packaging workflow is triggered by the workflow-file push; the connected workflow-run lookup did not yet expose a run for the final commit